### PR TITLE
Workaround fix for failing build on java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
                         <version>2.9.1</version>
                         <configuration>
                             <additionalparam>-Xdoclint:none</additionalparam>
+                            <detectJavaApiLink>false</detectJavaApiLink>
                         </configuration>
                         <executions>
                             <execution>
@@ -189,6 +190,7 @@
                         <version>2.9.1</version>
                         <configuration>
                             <additionalparam>-Xdoclint:none</additionalparam>
+                            <detectJavaApiLink>false</detectJavaApiLink>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION

**Issue #, if available:**

Fixes failing build for java 11 and further. This is apparently a open bug in java 11. Ref: https://github.com/joel-costigliola/assertj-core/issues/1403

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics]()

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
