### PR TITLE
Support for custom keys in the logs

### DIFF
--- a/example/HelloWorldFunction/src/main/java/helloworld/App.java
+++ b/example/HelloWorldFunction/src/main/java/helloworld/App.java
@@ -14,8 +14,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import software.aws.lambda.logging.client.PowerLogger;
-import software.aws.lambda.logging.client.PowerToolsLogging;
+import software.aws.lambda.logging.PowerLogger;
+import software.aws.lambda.logging.PowerToolsLogging;
 
 /**
  * Handler for requests to Lambda function.

--- a/example/HelloWorldFunction/src/main/java/helloworld/AppStream.java
+++ b/example/HelloWorldFunction/src/main/java/helloworld/AppStream.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import software.aws.lambda.logging.client.PowerToolsLogging;
+import software.aws.lambda.logging.PowerToolsLogging;
 
 public class AppStream implements RequestStreamHandler {
     private static final ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/software/aws/lambda/logging/PowerLogger.java
+++ b/src/main/java/software/aws/lambda/logging/PowerLogger.java
@@ -1,4 +1,4 @@
-package software.aws.lambda.logging.client;
+package software.aws.lambda.logging;
 
 import org.apache.logging.log4j.ThreadContext;
 

--- a/src/main/java/software/aws/lambda/logging/PowerToolsLogging.java
+++ b/src/main/java/software/aws/lambda/logging/PowerToolsLogging.java
@@ -1,4 +1,4 @@
-package software.aws.lambda.logging.client;
+package software.aws.lambda.logging;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/software/aws/lambda/logging/internal/DefaultLambdaFields.java
+++ b/src/main/java/software/aws/lambda/logging/internal/DefaultLambdaFields.java
@@ -1,4 +1,4 @@
-package software.aws.lambda.logging;
+package software.aws.lambda.logging.internal;
 
 import com.amazonaws.services.lambda.runtime.Context;
 

--- a/src/main/java/software/aws/lambda/logging/internal/LambdaAspect.java
+++ b/src/main/java/software/aws/lambda/logging/internal/LambdaAspect.java
@@ -1,4 +1,4 @@
-package software.aws.lambda.logging;
+package software.aws.lambda.logging.internal;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -21,7 +21,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
-import software.aws.lambda.logging.client.PowerToolsLogging;
+import software.aws.lambda.logging.PowerToolsLogging;
 
 import static java.util.Optional.empty;
 import static java.util.Optional.of;

--- a/src/test/java/software/aws/lambda/logging/PowerLoggerTest.java
+++ b/src/test/java/software/aws/lambda/logging/PowerLoggerTest.java
@@ -1,12 +1,19 @@
-package software.aws.lambda.logging.client;
+package software.aws.lambda.logging;
 
 import org.apache.logging.log4j.ThreadContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.aws.lambda.logging.PowerLogger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 
 class PowerLoggerTest {
+
+    @BeforeEach
+    void setUp() {
+        ThreadContext.clearAll();
+    }
 
     @Test
     void shouldSetCustomKeyOnThreadContext() {

--- a/src/test/java/software/aws/lambda/logging/internal/LambdaAspectTest.java
+++ b/src/test/java/software/aws/lambda/logging/internal/LambdaAspectTest.java
@@ -1,4 +1,4 @@
-package software.aws.lambda.logging;
+package software.aws.lambda.logging.internal;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/src/test/java/software/aws/lambda/logging/internal/PowerLogToolDisabled.java
+++ b/src/test/java/software/aws/lambda/logging/internal/PowerLogToolDisabled.java
@@ -1,12 +1,10 @@
-package software.aws.lambda.logging;
+package software.aws.lambda.logging.internal;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
-import software.aws.lambda.logging.client.PowerToolsLogging;
 
-public class PowerToolLogEventEnabled implements RequestHandler<Object, Object> {
+public class PowerLogToolDisabled implements RequestHandler<Object, Object> {
 
-    @PowerToolsLogging(logEvent = true)
     @Override
     public Object handleRequest(Object input, Context context) {
         return null;

--- a/src/test/java/software/aws/lambda/logging/internal/PowerLogToolDisabledForStream.java
+++ b/src/test/java/software/aws/lambda/logging/internal/PowerLogToolDisabledForStream.java
@@ -1,15 +1,13 @@
-package software.aws.lambda.logging;
+package software.aws.lambda.logging.internal;
 
 import java.io.InputStream;
 import java.io.OutputStream;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
-import software.aws.lambda.logging.client.PowerToolsLogging;
 
-public class PowerLogToolEnabledForStream implements RequestStreamHandler {
+public class PowerLogToolDisabledForStream implements RequestStreamHandler {
 
-    @PowerToolsLogging
     @Override
     public void handleRequest(InputStream input, OutputStream output, Context context) {
 

--- a/src/test/java/software/aws/lambda/logging/internal/PowerLogToolEnabled.java
+++ b/src/test/java/software/aws/lambda/logging/internal/PowerLogToolEnabled.java
@@ -1,8 +1,8 @@
-package software.aws.lambda.logging;
+package software.aws.lambda.logging.internal;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
-import software.aws.lambda.logging.client.PowerToolsLogging;
+import software.aws.lambda.logging.PowerToolsLogging;
 
 public class PowerLogToolEnabled implements RequestHandler<Object, Object> {
 

--- a/src/test/java/software/aws/lambda/logging/internal/PowerLogToolEnabledForStream.java
+++ b/src/test/java/software/aws/lambda/logging/internal/PowerLogToolEnabledForStream.java
@@ -1,13 +1,15 @@
-package software.aws.lambda.logging;
+package software.aws.lambda.logging.internal;
 
 import java.io.InputStream;
 import java.io.OutputStream;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import software.aws.lambda.logging.PowerToolsLogging;
 
-public class PowerLogToolDisabledForStream implements RequestStreamHandler {
+public class PowerLogToolEnabledForStream implements RequestStreamHandler {
 
+    @PowerToolsLogging
     @Override
     public void handleRequest(InputStream input, OutputStream output, Context context) {
 

--- a/src/test/java/software/aws/lambda/logging/internal/PowerToolLogEventEnabled.java
+++ b/src/test/java/software/aws/lambda/logging/internal/PowerToolLogEventEnabled.java
@@ -1,10 +1,12 @@
-package software.aws.lambda.logging;
+package software.aws.lambda.logging.internal;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import software.aws.lambda.logging.PowerToolsLogging;
 
-public class PowerLogToolDisabled implements RequestHandler<Object, Object> {
+public class PowerToolLogEventEnabled implements RequestHandler<Object, Object> {
 
+    @PowerToolsLogging(logEvent = true)
     @Override
     public Object handleRequest(Object input, Context context) {
         return null;

--- a/src/test/java/software/aws/lambda/logging/internal/PowerToolLogEventEnabledForStream.java
+++ b/src/test/java/software/aws/lambda/logging/internal/PowerToolLogEventEnabledForStream.java
@@ -1,4 +1,4 @@
-package software.aws.lambda.logging;
+package software.aws.lambda.logging.internal;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -8,7 +8,7 @@ import java.util.Map;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import software.aws.lambda.logging.client.PowerToolsLogging;
+import software.aws.lambda.logging.PowerToolsLogging;
 
 public class PowerToolLogEventEnabledForStream implements RequestStreamHandler {
 


### PR DESCRIPTION
This is suggestive implementation of supporting custom keys in structured log.

- We exposed a API for clients to set custom keys
- We maintain all the custom keys that client is willing to send as part of annotation. This gives a consolidated overview to clients as to what custom keys lambda might be logging.
- It also prevents clients from passing custom keys via default ThreadContext APIs

Other option is that when client calls the exposed API method, we maintain those custom keys ourselves. Which is ok as and is up for discussion. 

Reason for putting it at annotation level is that it gives nice overview of all the custom keys but many be its just additional overhead. 

This is Up for discussion.

PS: I will write tests after we finalize the approach