### PR TITLE
fix: issue-92

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,11 @@
             </dependency>
             <dependency>
                 <groupId>com.amazonaws</groupId>
+                <artifactId>aws-xray-recorder-sdk-aws-sdk-core</artifactId>
+                <version>${aws.xray.recorder.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
                 <artifactId>aws-xray-recorder-sdk-aws-sdk</artifactId>
                 <version>${aws.xray.recorder.version}</version>
             </dependency>

--- a/powertools-tracing/pom.xml
+++ b/powertools-tracing/pom.xml
@@ -72,6 +72,10 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
+            <artifactId>aws-xray-recorder-sdk-aws-sdk-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
             <artifactId>aws-xray-recorder-sdk-aws-sdk</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
**Issue #, if available:**

https://github.com/awslabs/aws-lambda-powertools-java/issues/92

## Description of changes:

The issue came about because aws-xray-recorder-sdk-aws-sdk-core was a runtime dependency and not compile. This caused a NoClassDefFoundError exception during local testing.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics]()

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
