### PR TITLE
feat: integration with CloudWatch ServiceLens #88

### DIFF
--- a/docs/content/core/logging.mdx
+++ b/docs/content/core/logging.mdx
@@ -69,7 +69,7 @@ Key | Type | Example | Description
 **functionVersion**| String | "12"
 **functionMemorySize**| String | "128"
 **functionArn**| String | "arn:aws:lambda:eu-west-1:012345678910:function:example-powertools-HelloWorldFunction-1P1Z6B39FLU73"
-
+**xray_trace_id**| String | "1-5759e988-bd862e3fe1be46a994272793" | X-Ray Trace ID when Lambda function has enabled Tracing
 
 ## Capturing context Lambda info
 

--- a/powertools-logging/pom.xml
+++ b/powertools-logging/pom.xml
@@ -89,6 +89,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
             <scope>test</scope>

--- a/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspect.java
+++ b/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspect.java
@@ -36,6 +36,8 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import software.amazon.lambda.powertools.logging.PowertoolsLogging;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.ofNullable;
 import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor.coldStartDone;
 import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor.extractContext;
 import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor.isColdStart;
@@ -45,6 +47,7 @@ import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProce
 import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor.serviceName;
 import static software.amazon.lambda.powertools.logging.PowertoolsLogger.appendKey;
 import static software.amazon.lambda.powertools.logging.PowertoolsLogger.appendKeys;
+import static software.amazon.lambda.powertools.logging.internal.SystemWrapper.getenv;
 
 @Aspect
 public final class LambdaLoggingAspect {
@@ -183,10 +186,10 @@ public final class LambdaLoggingAspect {
     }
 
     private static Optional<String> getXrayTraceId() {
-        final String X_AMZN_TRACE_ID = SystemWrapper.getenv("_X_AMZN_TRACE_ID");
+        final String X_AMZN_TRACE_ID = getenv("_X_AMZN_TRACE_ID");
         if(X_AMZN_TRACE_ID != null) {
-            return Optional.ofNullable(X_AMZN_TRACE_ID.split(";")[0].replace("Root=", ""));
+            return ofNullable(X_AMZN_TRACE_ID.split(";")[0].replace("Root=", ""));
         }
-        return Optional.empty();
+        return empty();
     }
 }

--- a/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspect.java
+++ b/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspect.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -83,6 +84,7 @@ public final class LambdaLoggingAspect {
                     appendKey("service", serviceName());
                 });
 
+        getXrayTraceId().ifPresent(xRayTraceId -> appendKey("xray_trace_id", xRayTraceId));
 
         if (powertoolsLogging.logEvent()) {
             proceedArgs = logEvent(pjp);
@@ -178,5 +180,13 @@ public final class LambdaLoggingAspect {
 
     private Logger logger(final ProceedingJoinPoint pjp) {
         return LogManager.getLogger(pjp.getSignature().getDeclaringType());
+    }
+
+    private static Optional<String> getXrayTraceId() {
+        final String X_AMZN_TRACE_ID = SystemWrapper.getenv("_X_AMZN_TRACE_ID");
+        if(X_AMZN_TRACE_ID != null) {
+            return Optional.ofNullable(X_AMZN_TRACE_ID.split(";")[0].replace("Root=", ""));
+        }
+        return Optional.empty();
     }
 }

--- a/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/SystemWrapper.java
+++ b/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/SystemWrapper.java
@@ -1,7 +1,7 @@
 package software.amazon.lambda.powertools.logging.internal;
 
-public class SystemWrapper {
-    public SystemWrapper() {
+class SystemWrapper {
+    private SystemWrapper() {
     }
 
     public static String getenv(String name) {

--- a/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/SystemWrapper.java
+++ b/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/SystemWrapper.java
@@ -1,0 +1,10 @@
+package software.amazon.lambda.powertools.logging.internal;
+
+public class SystemWrapper {
+    public SystemWrapper() {
+    }
+
+    public static String getenv(String name) {
+        return System.getenv(name);
+    }
+}

--- a/powertools-logging/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspectTest.java
+++ b/powertools-logging/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspectTest.java
@@ -40,8 +40,10 @@ import software.amazon.lambda.powertools.logging.handlers.PowerToolLogEventEnabl
 
 import static org.apache.commons.lang3.reflect.FieldUtils.writeStaticField;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
+import static software.amazon.lambda.powertools.logging.internal.SystemWrapper.getenv;
 
 class LambdaLoggingAspectTest {
 
@@ -178,8 +180,8 @@ class LambdaLoggingAspectTest {
     void shouldLogxRayTraceIdEnvVarSet() {
         String xRayTraceId = "1-5759e988-bd862e3fe1be46a994272793";
 
-        try (MockedStatic<SystemWrapper> mocked = Mockito.mockStatic(SystemWrapper.class)) {
-            mocked.when(() -> SystemWrapper.getenv("_X_AMZN_TRACE_ID")).thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1\"");
+        try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class)) {
+            mocked.when(() -> getenv("_X_AMZN_TRACE_ID")).thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1\"");
 
             requestHandler.handleRequest(new Object(), context);
 

--- a/powertools-logging/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspectTest.java
+++ b/powertools-logging/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspectTest.java
@@ -28,6 +28,8 @@ import org.apache.logging.log4j.ThreadContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor;
 import software.amazon.lambda.powertools.logging.handlers.PowerLogToolEnabled;
 import software.amazon.lambda.powertools.logging.handlers.PowerLogToolEnabledForStream;
@@ -39,7 +41,7 @@ import software.amazon.lambda.powertools.logging.handlers.PowerToolLogEventEnabl
 import static org.apache.commons.lang3.reflect.FieldUtils.writeStaticField;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 class LambdaLoggingAspectTest {
 
@@ -52,7 +54,7 @@ class LambdaLoggingAspectTest {
 
     @BeforeEach
     void setUp() throws IllegalAccessException {
-        initMocks(this);
+        openMocks(this);
         ThreadContext.clearAll();
         writeStaticField(LambdaHandlerProcessor.class, "IS_COLD_START", null, true);
         setupContext();
@@ -170,6 +172,21 @@ class LambdaLoggingAspectTest {
         assertThat(ThreadContext.getImmutableContext())
                 .hasSize(EXPECTED_CONTEXT_SIZE)
                 .containsEntry("service", "testService");
+    }
+
+    @Test
+    void shouldLogxRayTraceIdEnvVarSet() {
+        String xRayTraceId = "1-5759e988-bd862e3fe1be46a994272793";
+
+        try (MockedStatic<SystemWrapper> mocked = Mockito.mockStatic(SystemWrapper.class)) {
+            mocked.when(() -> SystemWrapper.getenv("_X_AMZN_TRACE_ID")).thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1\"");
+
+            requestHandler.handleRequest(new Object(), context);
+
+            assertThat(ThreadContext.getImmutableContext())
+                    .hasSize(EXPECTED_CONTEXT_SIZE + 1)
+                    .containsEntry("xray_trace_id", xRayTraceId);
+        }
     }
 
     private void setupContext() {


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

Closes #88 

Integration with CloudWatch ServiceLens:
The xray_trace_id key is added to log output when tracing is active. This enables the log correlation functionality in ServiceLens to work with applications using powertools.

**Checklist**

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics]()

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
