### PR TITLE
docs: add source code link in nav bar

### DIFF
--- a/docs/src/gatsby-theme-apollo-docs/components/page-content.js
+++ b/docs/src/gatsby-theme-apollo-docs/components/page-content.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import SectionNav from './section-nav';
 import styled from '@emotion/styled';
 import useMount from 'react-use/lib/useMount';
@@ -179,8 +179,9 @@ export default function PageContent(props) {
         );
     });
 
-    const githubUrl = props.githubUrl.replace("tree/", "blob/")
+   const githubUrl = props.githubUrl.replace("tree/", "blob/")
         .replace("/content/", "/docs/content/")
+	const sourceUrl = /.+?(?=tree)/.exec(props.githubUrl)
 
     const editLink = githubUrl && (
         <AsideLink href={githubUrl}>
@@ -210,6 +211,9 @@ export default function PageContent(props) {
                     />
                 )}
                 {editLink}
+                <AsideLink href={sourceUrl}>
+					<IconGithub /> Source code
+				</AsideLink>
             </Aside>
         </Wrapper>
     );
@@ -218,11 +222,12 @@ export default function PageContent(props) {
 PageContent.propTypes = {
     children: PropTypes.node.isRequired,
     pathname: PropTypes.string.isRequired,
-    githubUrl: PropTypes.string,
+    githubUrl: PropTypes.string.isRequired,
     pages: PropTypes.array.isRequired,
     hash: PropTypes.string.isRequired,
     title: PropTypes.string.isRequired,
-    graphManagerUrl: PropTypes.string.isRequired,
+    graphManagerUrl: PropTypes.string,
     headings: PropTypes.array.isRequired,
     spectrumUrl: PropTypes.string
 };
+


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

Adds Source code URL in the side bar to keep in sync with Python docs ;)

![image](https://user-images.githubusercontent.com/3340292/100431255-2f338580-3098-11eb-8a86-1dd5a46a6c82.png)


**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics]()

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
