### PR TITLE
 ci: add JDK 15 to build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       max-parallel: 4
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
-        java: [8, 8.0.192, 11.0.x, 11.0.3, 12, 13 ]
+        java: [8, 8.0.192, 11.0.x, 11.0.3, 12, 13, 15 ]
     name: Java ${{ matrix.java }}
     env:
       OS: ${{ matrix.os }}


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

add JDK 15 to CI build matrix

https://jdk.java.net/15/

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics]()

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
