### PR TITLE
refactor: replace Apache Commons Logging with SLF4J

### DIFF
--- a/powertools-sqs/src/main/java/software/amazon/lambda/powertools/sqs/SqsUtils.java
+++ b/powertools-sqs/src/main/java/software/amazon/lambda/powertools/sqs/SqsUtils.java
@@ -22,8 +22,10 @@ import java.util.stream.Collectors;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.lambda.powertools.sqs.internal.BatchContext;
 import software.amazon.lambda.powertools.sqs.internal.SqsLargeMessageAspect;
@@ -36,7 +38,7 @@ import static software.amazon.lambda.powertools.sqs.internal.SqsLargeMessageAspe
  * A class of helper functions to add additional functionality to {@link SQSEvent} processing.
  */
 public final class SqsUtils {
-    private static final Log LOG = LogFactory.getLog(SqsUtils.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SqsUtils.class);
 
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private static SqsClient client = SqsClient.create();

--- a/powertools-sqs/src/main/java/software/amazon/lambda/powertools/sqs/internal/BatchContext.java
+++ b/powertools-sqs/src/main/java/software/amazon/lambda/powertools/sqs/internal/BatchContext.java
@@ -1,10 +1,11 @@
 package software.amazon.lambda.powertools.sqs.internal;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequest;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageBatchRequestEntry;
@@ -17,7 +18,7 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 
 public final class BatchContext {
-    private static final Log LOG = LogFactory.getLog(BatchContext.class);
+    private static final Logger LOG = LoggerFactory.getLogger(BatchContext.class);
 
     private final List<SQSMessage> success = new ArrayList<>();
     private final List<SQSMessage> failures = new ArrayList<>();

--- a/powertools-sqs/src/main/java/software/amazon/lambda/powertools/sqs/internal/SqsLargeMessageAspect.java
+++ b/powertools-sqs/src/main/java/software/amazon/lambda/powertools/sqs/internal/SqsLargeMessageAspect.java
@@ -14,12 +14,14 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.util.IOUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import software.amazon.lambda.powertools.sqs.SqsLargeMessage;
 import software.amazon.payloadoffloading.PayloadS3Pointer;
 
@@ -30,7 +32,7 @@ import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProce
 @Aspect
 public class SqsLargeMessageAspect {
 
-    private static final Log LOG = LogFactory.getLog(SqsLargeMessageAspect.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SqsLargeMessageAspect.class);
     private static AmazonS3 amazonS3 = AmazonS3ClientBuilder.defaultClient();
 
     @SuppressWarnings({"EmptyMethod"})


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

replace Apache Commons Logging with SLF4J

Apache Commons Logging is an obsolete library and should not be used in
modern Java systems.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics]()

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
