### PR TITLE
feat: custom segment names

### DIFF
--- a/docs/content/core/tracing.mdx
+++ b/docs/content/core/tracing.mdx
@@ -62,6 +62,8 @@ public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatew
 ```
 
 By default this annotation will automatically record method responses and exceptions.
+If you want to customize segment name that appears in traces, use:
+`@Tracing(segmentName="yourCustomName")`
 
 <Note type="warning">
   <strong>Returning sensitive information from your Lambda handler or functions, where Tracer is used?</strong>

--- a/powertools-tracing/src/main/java/software/amazon/lambda/powertools/tracing/Tracing.java
+++ b/powertools-tracing/src/main/java/software/amazon/lambda/powertools/tracing/Tracing.java
@@ -50,4 +50,5 @@ public @interface Tracing {
     String namespace() default "";
     boolean captureResponse() default true;
     boolean captureError() default true;
+    String segmentName() default "";
 }

--- a/powertools-tracing/src/test/java/software/amazon/lambda/powertools/tracing/nonhandler/PowerToolNonHandler.java
+++ b/powertools-tracing/src/test/java/software/amazon/lambda/powertools/tracing/nonhandler/PowerToolNonHandler.java
@@ -1,0 +1,14 @@
+package software.amazon.lambda.powertools.tracing.nonhandler;
+
+import software.amazon.lambda.powertools.tracing.Tracing;
+
+public class PowerToolNonHandler {
+
+    @Tracing
+    public void doSomething() {
+    }
+
+    @Tracing(segmentName = "custom")
+    public void doSomethingCustomName() {
+    }
+}


### PR DESCRIPTION
* add segmentName attribute to Trace annotation
* if segmentName is provided, use it as subsegment name instead of traced
method's name

**Issue #, if available:**

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics]()

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
