### PR TITLE
feat: capture metrics even when handler results in exception

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
       - 'powertools-tracing/**'
       - 'powertools-validation/**'
       - 'powertools-parameters/**'
+      - 'powertools-metrics/**'
       - 'pom.xml'
       - '.github/workflows/**'
   push:
@@ -21,8 +22,11 @@ on:
       - 'powertools-logging/**'
       - 'powertools-sqs/**'
       - 'powertools-tracing/**'
+      - 'powertools-validation/**'
+      - 'powertools-parameters/**'
+      - 'powertools-metrics/**'
       - 'pom.xml'
-
+      - '.github/workflows/**'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsWithExceptionInHandler.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsWithExceptionInHandler.java
@@ -1,0 +1,19 @@
+package software.amazon.lambda.powertools.metrics.handlers;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
+import software.amazon.lambda.powertools.metrics.Metrics;
+
+import static software.amazon.lambda.powertools.metrics.MetricsUtils.metricsLogger;
+
+public class PowertoolsMetricsWithExceptionInHandler implements RequestHandler<Object, Object> {
+
+    @Override
+    @Metrics(namespace = "ExampleApplication", service = "booking")
+    public Object handleRequest(Object input, Context context) {
+        MetricsLogger metricsLogger = metricsLogger();
+        metricsLogger.putMetric("CoolMetric", 1);
+        throw new IllegalStateException("Whoops, unexpected exception");
+    }
+}


### PR DESCRIPTION
**Issue #285 

## Description of changes:

capture metrics even when handler results in exception

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [x] Update tests
* [x] ~~Update docs~~
* [x] PR title follows [conventional commit semantics]()

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [x] ~~Migration process documented~~
* [x] ~~Implement warnings (if it can live side by side)~~

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
