### PR TITLE
feat: Override object mapper

### DIFF
--- a/docs/content/core/logging.mdx
+++ b/docs/content/core/logging.mdx
@@ -100,6 +100,7 @@ public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatew
 ```
 
 You can also explicitly log any incoming event using `logEvent` param.
+Refer [Override default object mapper](#override-default-object-mapper) to customise what is logged.
 
 <Note type="warning">
    This is disabled by default to prevent sensitive info being logged.
@@ -160,6 +161,42 @@ public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatew
          customKeys.put("test1", "value1");
 
          LoggingUtils.appendKeys(customKeys);
+        ...
+    }
+}
+```
+
+## Override default object mapper
+
+You can optionally choose to override default object mapper which is used to serialize lambda function events. You might
+want to supply custom object mapper in order to control how serialisation is done, for example, when you want to log only
+specific fields from received event due to security.
+
+```java:title=App.java
+package helloworld;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.lambda.logging.LoggingUtils;
+import software.amazon.lambda.logging.Logging;
+...
+
+/**
+ * Handler for requests to Lambda function.
+ */
+public class App implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    Logger log = LogManager.getLogger();
+
+    // highlight-start
+    static {
+        ObjectMapper objectMapper = new ObjectMapper();
+        LoggingUtils.defaultObjectMapper(objectMapper);
+    }
+    // highlight-end
+
+    @Logging(logEvent = true)
+    public APIGatewayProxyResponseEvent handleRequest(final APIGatewayProxyRequestEvent input, final Context context) {
         ...
     }
 }

--- a/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/LoggingUtils.java
+++ b/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/LoggingUtils.java
@@ -15,6 +15,7 @@ package software.amazon.lambda.powertools.logging;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.ThreadContext;
 
 /**
@@ -23,6 +24,7 @@ import org.apache.logging.log4j.ThreadContext;
  * {@see Logging}
  */
 public final class LoggingUtils {
+    private static ObjectMapper objectMapper = new ObjectMapper();
 
     private LoggingUtils() {
     }
@@ -47,5 +49,19 @@ public final class LoggingUtils {
      */
     public static void appendKeys(Map<String, String> customKeys) {
         ThreadContext.putAll(customKeys);
+    }
+
+    /**
+     * Sets the instance of ObjectMapper object which is used for serialising event when
+     * {@code @Logging(logEvent = true)}.
+     *
+     * @param objectMapper Custom implementation of object mapper to be used for logging serialised event
+     */
+    public static void defaultObjectMapper(ObjectMapper objectMapper) {
+        LoggingUtils.objectMapper = objectMapper;
+    }
+
+    public static ObjectMapper objectMapper() {
+        return objectMapper;
     }
 }

--- a/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspect.java
+++ b/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspect.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import java.util.Random;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -49,12 +48,12 @@ import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProce
 import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor.serviceName;
 import static software.amazon.lambda.powertools.logging.LoggingUtils.appendKey;
 import static software.amazon.lambda.powertools.logging.LoggingUtils.appendKeys;
+import static software.amazon.lambda.powertools.logging.LoggingUtils.objectMapper;
 import static software.amazon.lambda.powertools.logging.internal.SystemWrapper.getenv;
 
 @Aspect
 public final class LambdaLoggingAspect {
     private static final Logger LOG = LogManager.getLogger(LambdaLoggingAspect.class);
-    private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final Random SAMPLER = new Random();
 
     private static final String LOG_LEVEL = System.getenv("LOG_LEVEL");
@@ -175,7 +174,7 @@ public final class LambdaLoggingAspect {
 
             Logger log = logger(pjp);
 
-            asJson(pjp, MAPPER.readValue(bytes, Map.class))
+            asJson(pjp, objectMapper().readValue(bytes, Map.class))
                     .ifPresent(log::info);
 
         } catch (IOException e) {
@@ -189,7 +188,7 @@ public final class LambdaLoggingAspect {
     private Optional<String> asJson(final ProceedingJoinPoint pjp,
                                     final Object target) {
         try {
-            return ofNullable(MAPPER.writeValueAsString(target));
+            return ofNullable(objectMapper().writeValueAsString(target));
         } catch (JsonProcessingException e) {
             logger(pjp).error("Failed logging event of type {}", target.getClass(), e);
             return empty();

--- a/powertools-logging/src/test/java/software/amazon/lambda/powertools/logging/handlers/PowerToolLogEventEnabledWithCustomMapper.java
+++ b/powertools-logging/src/test/java/software/amazon/lambda/powertools/logging/handlers/PowerToolLogEventEnabledWithCustomMapper.java
@@ -1,0 +1,49 @@
+package software.amazon.lambda.powertools.logging.handlers;
+
+import java.io.IOException;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import software.amazon.lambda.powertools.logging.Logging;
+import software.amazon.lambda.powertools.logging.LoggingUtils;
+
+public class PowerToolLogEventEnabledWithCustomMapper implements RequestHandler<S3EventNotification, Object> {
+
+    static {
+        ObjectMapper objectMapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(S3EventNotification.class, new S3EventNotificationSerializer());
+        objectMapper.registerModule(module);
+        LoggingUtils.defaultObjectMapper(objectMapper);
+    }
+
+    @Logging(logEvent = true)
+    @Override
+    public Object handleRequest(S3EventNotification input, Context context) {
+        return null;
+    }
+
+    static class S3EventNotificationSerializer extends StdSerializer<S3EventNotification> {
+
+        public S3EventNotificationSerializer() {
+            this(null);
+        }
+
+        public S3EventNotificationSerializer(Class<S3EventNotification> t) {
+            super(t);
+        }
+
+        @Override
+        public void serialize(S3EventNotification o, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+            jsonGenerator.writeStartObject();
+            jsonGenerator.writeStringField("eventSource", o.getRecords().get(0).getEventSource());
+            jsonGenerator.writeEndObject();
+        }
+    }
+}

--- a/powertools-logging/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspectTest.java
+++ b/powertools-logging/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspectTest.java
@@ -47,6 +47,7 @@ import software.amazon.lambda.powertools.logging.handlers.PowerToolDisabled;
 import software.amazon.lambda.powertools.logging.handlers.PowerToolDisabledForStream;
 import software.amazon.lambda.powertools.logging.handlers.PowerToolLogEventEnabled;
 import software.amazon.lambda.powertools.logging.handlers.PowerToolLogEventEnabledForStream;
+import software.amazon.lambda.powertools.logging.handlers.PowerToolLogEventEnabledWithCustomMapper;
 
 import static com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification.RequestParametersEntity;
 import static com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification.ResponseElementsEntity;
@@ -178,6 +179,23 @@ class LambdaLoggingAspectTest {
         String event = (String) log.get("message");
 
         String expectEvent = new BufferedReader(new InputStreamReader(this.getClass().getResourceAsStream("/s3EventNotification.json")))
+                .lines().collect(joining("\n"));
+
+        assertEquals(expectEvent, event, false);
+    }
+
+    @Test
+    void shouldLogEventForHandlerWithOverriddenObjectMapper() throws IOException, JSONException {
+        RequestHandler<S3EventNotification, Object> handler = new PowerToolLogEventEnabledWithCustomMapper();
+        S3EventNotification s3EventNotification = s3EventNotification();
+
+        handler.handleRequest(s3EventNotification, context);
+
+        Map<String, Object> log = parseToMap(Files.lines(Paths.get("target/logfile.json")).collect(joining()));
+
+        String event = (String) log.get("message");
+
+        String expectEvent = new BufferedReader(new InputStreamReader(this.getClass().getResourceAsStream("/customizedLogEvent.json")))
                 .lines().collect(joining("\n"));
 
         assertEquals(expectEvent, event, false);

--- a/powertools-logging/src/test/resources/customizedLogEvent.json
+++ b/powertools-logging/src/test/resources/customizedLogEvent.json
@@ -1,0 +1,3 @@
+{
+  "eventSource": "aws:s3"
+}


### PR DESCRIPTION
**Issue #275 and #66 

## Description of changes:

Ability to override default object mapper used for serialization while logging received event. This can also be used to control what is logged from event based on the configuration of object mapper. Refer [PowerToolLogEventEnabledWithCustomMapper.java ](https://github.com/awslabs/aws-lambda-powertools-java/compare/override-object-mapper?expand=1#diff-2cbe80bce7fa67f977ebe28b0c9c0470d77b2b4b426df42bce658dce5456bd1c)

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics]()

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [x] ~~Migration process documented~~
* [x] ~~Implement warnings (if it can live side by side)~~

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
