### PR TITLE
Issue 297: Add AwsRequestId to each EMF log.

### DIFF
--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/internal/LambdaMetricsAspectTest.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/internal/LambdaMetricsAspectTest.java
@@ -82,6 +82,7 @@ public class LambdaMetricsAspectTest {
                         assertThat(logAsJson)
                                 .containsEntry("Metric1", 1.0)
                                 .containsEntry("Service", "booking")
+                                .containsEntry("AwsRequestId", "123ABC")
                                 .containsKey("_aws");
                     });
         }
@@ -105,6 +106,7 @@ public class LambdaMetricsAspectTest {
                                 .doesNotContainKey("Metric1")
                                 .containsEntry("ColdStart", 1.0)
                                 .containsEntry("Service", "booking")
+                                .containsEntry("AwsRequestId", "123ABC")
                                 .containsKey("_aws");
 
                         logAsJson = readAsJson(s[1]);
@@ -113,6 +115,7 @@ public class LambdaMetricsAspectTest {
                                 .doesNotContainKey("ColdStart")
                                 .containsEntry("Metric1", 1.0)
                                 .containsEntry("Service", "booking")
+                                .containsEntry("AwsRequestId", "123ABC")
                                 .containsKey("_aws");
                     });
         }
@@ -136,6 +139,7 @@ public class LambdaMetricsAspectTest {
                                 .doesNotContainKey("Metric1")
                                 .containsEntry("ColdStart", 1.0)
                                 .containsEntry("Service", "booking")
+                                .containsEntry("AwsRequestId", "123ABC")
                                 .containsKey("_aws");
 
                         logAsJson = readAsJson(s[1]);
@@ -144,6 +148,7 @@ public class LambdaMetricsAspectTest {
                                 .doesNotContainKey("ColdStart")
                                 .containsEntry("Metric1", 1.0)
                                 .containsEntry("Service", "booking")
+                                .containsEntry("AwsRequestId", "123ABC")
                                 .containsKey("_aws");
 
                         logAsJson = readAsJson(s[2]);
@@ -152,6 +157,7 @@ public class LambdaMetricsAspectTest {
                                 .doesNotContainKey("ColdStart")
                                 .containsEntry("Metric1", 1.0)
                                 .containsEntry("Service", "booking")
+                                .containsEntry("AwsRequestId", "123ABC")
                                 .containsKey("_aws");
                     });
         }
@@ -173,6 +179,7 @@ public class LambdaMetricsAspectTest {
                         assertThat(logAsJson)
                                 .containsEntry("Metric1", 1.0)
                                 .containsEntry("Service", "booking")
+                                .containsEntry("AwsRequestId", "123ABC")
                                 .containsKey("_aws");
                     });
         }
@@ -249,6 +256,7 @@ public class LambdaMetricsAspectTest {
                         assertThat(logAsJson)
                                 .containsEntry("CoolMetric", 1.0)
                                 .containsEntry("Service", "booking")
+                                .containsEntry("AwsRequestId", "123ABC")
                                 .containsKey("_aws");
                     });
         }
@@ -259,6 +267,7 @@ public class LambdaMetricsAspectTest {
         when(context.getInvokedFunctionArn()).thenReturn("testArn");
         when(context.getFunctionVersion()).thenReturn("1");
         when(context.getMemoryLimitInMB()).thenReturn(10);
+        when(context.getAwsRequestId()).thenReturn("123ABC");
     }
 
     private Map<String, Object> readAsJson(String s) {


### PR DESCRIPTION
**Issue #, if available:**

https://github.com/awslabs/aws-lambda-powertools-java/issues/297

## Description of changes:

Fix for point 2.
AwsRequestId is now added to each EMF log output.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics]()

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
