### PR TITLE
feat: single metric utility method to pick default namespace

### DIFF
--- a/powertools-core/src/main/java/software/amazon/lambda/powertools/core/internal/LambdaHandlerProcessor.java
+++ b/powertools-core/src/main/java/software/amazon/lambda/powertools/core/internal/LambdaHandlerProcessor.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
+import static software.amazon.lambda.powertools.core.internal.SystemWrapper.getenv;
 
 public final class LambdaHandlerProcessor {
     // SERVICE_NAME cannot be final for testing purposes
@@ -82,5 +83,13 @@ public final class LambdaHandlerProcessor {
 
     public static boolean isSamLocal() {
         return "true".equals(System.getenv("AWS_SAM_LOCAL"));
+    }
+
+    public static Optional<String> getXrayTraceId() {
+        final String X_AMZN_TRACE_ID = getenv("_X_AMZN_TRACE_ID");
+        if(X_AMZN_TRACE_ID != null) {
+            return of(X_AMZN_TRACE_ID.split(";")[0].replace("Root=", ""));
+        }
+        return empty();
     }
 }

--- a/powertools-core/src/main/java/software/amazon/lambda/powertools/core/internal/SystemWrapper.java
+++ b/powertools-core/src/main/java/software/amazon/lambda/powertools/core/internal/SystemWrapper.java
@@ -1,6 +1,6 @@
-package software.amazon.lambda.powertools.logging.internal;
+package software.amazon.lambda.powertools.core.internal;
 
-class SystemWrapper {
+public class SystemWrapper {
     private SystemWrapper() {
     }
 

--- a/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspect.java
+++ b/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspect.java
@@ -39,10 +39,10 @@ import software.amazon.lambda.powertools.logging.Logging;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Optional.empty;
-import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor.coldStartDone;
 import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor.extractContext;
+import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor.getXrayTraceId;
 import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor.isColdStart;
 import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor.isHandlerMethod;
 import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor.placedOnRequestHandler;
@@ -50,7 +50,6 @@ import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProce
 import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor.serviceName;
 import static software.amazon.lambda.powertools.logging.LoggingUtils.appendKey;
 import static software.amazon.lambda.powertools.logging.LoggingUtils.appendKeys;
-import static software.amazon.lambda.powertools.logging.internal.SystemWrapper.getenv;
 
 @Aspect
 public final class LambdaLoggingAspect {
@@ -199,13 +198,5 @@ public final class LambdaLoggingAspect {
 
     private Logger logger(final ProceedingJoinPoint pjp) {
         return LogManager.getLogger(pjp.getSignature().getDeclaringType());
-    }
-
-    private static Optional<String> getXrayTraceId() {
-        final String X_AMZN_TRACE_ID = getenv("_X_AMZN_TRACE_ID");
-        if(X_AMZN_TRACE_ID != null) {
-            return of(X_AMZN_TRACE_ID.split(";")[0].replace("Root=", ""));
-        }
-        return empty();
     }
 }

--- a/powertools-logging/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspectTest.java
+++ b/powertools-logging/src/test/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspectTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor;
+import software.amazon.lambda.powertools.core.internal.SystemWrapper;
 import software.amazon.lambda.powertools.logging.handlers.PowerLogToolEnabled;
 import software.amazon.lambda.powertools.logging.handlers.PowerLogToolEnabledForStream;
 import software.amazon.lambda.powertools.logging.handlers.PowerToolDisabled;
@@ -65,7 +66,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
-import static software.amazon.lambda.powertools.logging.internal.SystemWrapper.getenv;
+import static software.amazon.lambda.powertools.core.internal.SystemWrapper.getenv;
 
 class LambdaLoggingAspectTest {
 

--- a/powertools-metrics/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsLoggerHelper.java
+++ b/powertools-metrics/src/main/java/software/amazon/cloudwatchlogs/emf/model/MetricsLoggerHelper.java
@@ -16,7 +16,7 @@ public final class MetricsLoggerHelper {
         return metricsContext().getDimensions().size();
     }
 
-    private static MetricsContext metricsContext() {
+    public static MetricsContext metricsContext() {
         try {
             Field f = metricsLogger().getClass().getDeclaredField("context");
             f.setAccessible(true);

--- a/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/MetricsUtils.java
+++ b/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/MetricsUtils.java
@@ -2,7 +2,10 @@ package software.amazon.lambda.powertools.metrics;
 
 import java.util.function.Consumer;
 
+import software.amazon.cloudwatchlogs.emf.config.SystemWrapper;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
+import software.amazon.cloudwatchlogs.emf.model.MetricsContext;
+import software.amazon.cloudwatchlogs.emf.model.MetricsLoggerHelper;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 
 /**
@@ -27,6 +30,29 @@ public final class MetricsUtils {
     }
 
     /**
+     * Add and immediately flush a single metric. It will use the default namespace
+     * specific either on {@link Metrics} annotation or via POWERTOOLS_METRICS_NAMESPACE env var.
+     *
+     * @param name   the name of the metric
+     * @param value  the value of the metric
+     * @param unit   the unit type of the metric
+     * @param logger the MetricsLogger
+     */
+    public static void withSingleMetricOnDefaultNameSpace(final String name,
+                                                          final double value,
+                                                          final Unit unit,
+                                                          final Consumer<MetricsLogger> logger) {
+        MetricsLogger metricsLogger = new MetricsLogger();
+        try {
+            metricsLogger.setNamespace(defaultNameSpace());
+            metricsLogger.putMetric(name, value, unit);
+            logger.accept(metricsLogger);
+        } finally {
+            metricsLogger.flush();
+        }
+    }
+
+    /**
      * Add and immediately flush a single metric.
      *
      * @param name the name of the metric
@@ -48,5 +74,11 @@ public final class MetricsUtils {
         } finally {
             metricsLogger.flush();
         }
+    }
+
+    private static String defaultNameSpace() {
+        MetricsContext context = MetricsLoggerHelper.metricsContext();
+        return "aws-embedded-metrics".equals(context.getNamespace()) ?
+                SystemWrapper.getenv("POWERTOOLS_METRICS_NAMESPACE"): context.getNamespace();
     }
 }

--- a/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/MetricsUtils.java
+++ b/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/MetricsUtils.java
@@ -1,5 +1,6 @@
 package software.amazon.lambda.powertools.metrics;
 
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import software.amazon.cloudwatchlogs.emf.config.SystemWrapper;
@@ -7,6 +8,11 @@ import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.MetricsContext;
 import software.amazon.cloudwatchlogs.emf.model.MetricsLoggerHelper;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
+
+import static java.util.Optional.ofNullable;
+import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor.getXrayTraceId;
+import static software.amazon.lambda.powertools.metrics.internal.LambdaMetricsAspect.REQUEST_ID_PROPERTY;
+import static software.amazon.lambda.powertools.metrics.internal.LambdaMetricsAspect.TRACE_ID_PROPERTY;
 
 /**
  * A class used to retrieve the instance of the {@code MetricsLogger} used by
@@ -31,21 +37,24 @@ public final class MetricsUtils {
 
     /**
      * Add and immediately flush a single metric. It will use the default namespace
-     * specific either on {@link Metrics} annotation or via POWERTOOLS_METRICS_NAMESPACE env var.
+     * specified either on {@link Metrics} annotation or via POWERTOOLS_METRICS_NAMESPACE env var.
+     * It by default captures AwsRequestId as property if used together with {@link Metrics} annotation. It will also 
+     * capture XrayTraceId as property if tracing is enabled.
      *
      * @param name   the name of the metric
      * @param value  the value of the metric
      * @param unit   the unit type of the metric
      * @param logger the MetricsLogger
      */
-    public static void withSingleMetricOnDefaultNameSpace(final String name,
-                                                          final double value,
-                                                          final Unit unit,
-                                                          final Consumer<MetricsLogger> logger) {
+    public static void withSingleMetric(final String name,
+                                        final double value,
+                                        final Unit unit,
+                                        final Consumer<MetricsLogger> logger) {
         MetricsLogger metricsLogger = new MetricsLogger();
         try {
             metricsLogger.setNamespace(defaultNameSpace());
             metricsLogger.putMetric(name, value, unit);
+            captureRequestAndTraceId(metricsLogger);
             logger.accept(metricsLogger);
         } finally {
             metricsLogger.flush();
@@ -54,6 +63,8 @@ public final class MetricsUtils {
 
     /**
      * Add and immediately flush a single metric.
+     * It by default captures AwsRequestId as property if used together with {@link Metrics} annotation. It will also 
+     * capture XrayTraceId as property if tracing is enabled.
      *
      * @param name the name of the metric
      * @param value the value of the metric
@@ -70,15 +81,30 @@ public final class MetricsUtils {
         try {
             metricsLogger.setNamespace(namespace);
             metricsLogger.putMetric(name, value, unit);
+            captureRequestAndTraceId(metricsLogger);
             logger.accept(metricsLogger);
         } finally {
             metricsLogger.flush();
         }
     }
 
+    private static void captureRequestAndTraceId(MetricsLogger metricsLogger) {
+        awsRequestId().
+                ifPresent(requestId -> metricsLogger.putProperty(REQUEST_ID_PROPERTY, requestId));
+
+        getXrayTraceId()
+                .ifPresent(traceId -> metricsLogger.putProperty(TRACE_ID_PROPERTY, traceId));
+    }
+
     private static String defaultNameSpace() {
         MetricsContext context = MetricsLoggerHelper.metricsContext();
         return "aws-embedded-metrics".equals(context.getNamespace()) ?
                 SystemWrapper.getenv("POWERTOOLS_METRICS_NAMESPACE"): context.getNamespace();
+    }
+
+    private static Optional<String> awsRequestId() {
+        MetricsContext context = MetricsLoggerHelper.metricsContext();
+        return ofNullable(context.getProperty(REQUEST_ID_PROPERTY))
+                .map(Object::toString);
     }
 }

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/MetricsLoggerTest.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/MetricsLoggerTest.java
@@ -18,6 +18,7 @@ import software.amazon.cloudwatchlogs.emf.model.Unit;
 import static java.util.Collections.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mockStatic;
+import static software.amazon.lambda.powertools.core.internal.SystemWrapper.getenv;
 
 class MetricsLoggerTest {
 
@@ -44,8 +45,10 @@ class MetricsLoggerTest {
 
     @Test
     void singleMetricsCaptureUtility() {
-        try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class)) {
+        try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class);
+             MockedStatic<software.amazon.lambda.powertools.core.internal.SystemWrapper> internalWrapper = mockStatic(software.amazon.lambda.powertools.core.internal.SystemWrapper.class)) {
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
+            internalWrapper.when(() -> getenv("_X_AMZN_TRACE_ID")).thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1\"");
 
             MetricsUtils.withSingleMetric("Metric1", 1, Unit.COUNT, "test",
                     metricsLogger -> metricsLogger.setDimensions(DimensionSet.of("Dimension1", "Value1")));
@@ -57,18 +60,21 @@ class MetricsLoggerTest {
                         assertThat(logAsJson)
                                 .containsEntry("Metric1", 1.0)
                                 .containsEntry("Dimension1", "Value1")
-                                .containsKey("_aws");
+                                .containsKey("_aws")
+                                .containsEntry("XrayTraceId", "1-5759e988-bd862e3fe1be46a994272793");
                     });
         }
     }
 
     @Test
     void singleMetricsCaptureUtilityWithDefaultNameSpace() {
-        try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class)) {
+        try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class);
+             MockedStatic<software.amazon.lambda.powertools.core.internal.SystemWrapper> internalWrapper = mockStatic(software.amazon.lambda.powertools.core.internal.SystemWrapper.class)) {
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
             mocked.when(() -> SystemWrapper.getenv("POWERTOOLS_METRICS_NAMESPACE")).thenReturn("GlobalName");
+            internalWrapper.when(() -> getenv("_X_AMZN_TRACE_ID")).thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1\"");
 
-            MetricsUtils.withSingleMetricOnDefaultNameSpace("Metric1", 1, Unit.COUNT,
+            MetricsUtils.withSingleMetric("Metric1", 1, Unit.COUNT,
                     metricsLogger -> metricsLogger.setDimensions(DimensionSet.of("Dimension1", "Value1")));
 
             assertThat(out.toString())
@@ -78,7 +84,8 @@ class MetricsLoggerTest {
                         assertThat(logAsJson)
                                 .containsEntry("Metric1", 1.0)
                                 .containsEntry("Dimension1", "Value1")
-                                .containsKey("_aws");
+                                .containsKey("_aws")
+                                .containsEntry("XrayTraceId", "1-5759e988-bd862e3fe1be46a994272793");
 
                         Map<String, Object> aws = (Map<String, Object>) logAsJson.get("_aws");
 

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsEnabledHandler.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsEnabledHandler.java
@@ -3,10 +3,12 @@ package software.amazon.lambda.powertools.metrics.handlers;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
+import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 import software.amazon.lambda.powertools.metrics.Metrics;
 
 import static software.amazon.lambda.powertools.metrics.MetricsUtils.metricsLogger;
+import static software.amazon.lambda.powertools.metrics.MetricsUtils.withSingleMetricOnDefaultNameSpace;
 
 public class PowertoolsMetricsEnabledHandler implements RequestHandler<Object, Object> {
 
@@ -15,6 +17,10 @@ public class PowertoolsMetricsEnabledHandler implements RequestHandler<Object, O
     public Object handleRequest(Object input, Context context) {
         MetricsLogger metricsLogger = metricsLogger();
         metricsLogger.putMetric("Metric1", 1, Unit.BYTES);
+
+
+        withSingleMetricOnDefaultNameSpace("Metric2", 1, Unit.COUNT,
+                log -> log.setDimensions(DimensionSet.of("Dimension1", "Value1")));
 
         return null;
     }

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsEnabledHandler.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsEnabledHandler.java
@@ -8,7 +8,7 @@ import software.amazon.cloudwatchlogs.emf.model.Unit;
 import software.amazon.lambda.powertools.metrics.Metrics;
 
 import static software.amazon.lambda.powertools.metrics.MetricsUtils.metricsLogger;
-import static software.amazon.lambda.powertools.metrics.MetricsUtils.withSingleMetricOnDefaultNameSpace;
+import static software.amazon.lambda.powertools.metrics.MetricsUtils.withSingleMetric;
 
 public class PowertoolsMetricsEnabledHandler implements RequestHandler<Object, Object> {
 
@@ -19,7 +19,7 @@ public class PowertoolsMetricsEnabledHandler implements RequestHandler<Object, O
         metricsLogger.putMetric("Metric1", 1, Unit.BYTES);
 
 
-        withSingleMetricOnDefaultNameSpace("Metric2", 1, Unit.COUNT,
+        withSingleMetric("Metric2", 1, Unit.COUNT,
                 log -> log.setDimensions(DimensionSet.of("Dimension1", "Value1")));
 
         return null;

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/internal/LambdaMetricsAspectTest.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/internal/LambdaMetricsAspectTest.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
+import static software.amazon.lambda.powertools.core.internal.SystemWrapper.getenv;
 
 public class LambdaMetricsAspectTest {
     @Mock
@@ -71,8 +72,12 @@ public class LambdaMetricsAspectTest {
 
     @Test
     public void metricsWithoutColdStart() {
-        try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class)) {
+        try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class);
+             MockedStatic<software.amazon.lambda.powertools.core.internal.SystemWrapper> internalWrapper = mockStatic(software.amazon.lambda.powertools.core.internal.SystemWrapper.class)) {
+
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
+            internalWrapper.when(() -> getenv("_X_AMZN_TRACE_ID")).thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1\"");
+
             requestHandler.handleRequest("input", context);
 
             assertThat(out.toString().split("\n"))
@@ -83,7 +88,9 @@ public class LambdaMetricsAspectTest {
                         assertThat(logAsJson)
                                 .containsEntry("Metric2", 1.0)
                                 .containsEntry("Dimension1", "Value1")
-                                .containsKey("_aws");
+                                .containsKey("_aws")
+                                .containsEntry("XrayTraceId", "1-5759e988-bd862e3fe1be46a994272793")
+                                .containsEntry("AwsRequestId", "123ABC");
 
                         Map<String, Object> aws = (Map<String, Object>) logAsJson.get("_aws");
 

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/internal/LambdaMetricsAspectTest.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/internal/LambdaMetricsAspectTest.java
@@ -75,9 +75,23 @@ public class LambdaMetricsAspectTest {
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
             requestHandler.handleRequest("input", context);
 
-            assertThat(out.toString())
+            assertThat(out.toString().split("\n"))
+                    .hasSize(2)
                     .satisfies(s -> {
-                        Map<String, Object> logAsJson = readAsJson(s);
+                        Map<String, Object> logAsJson = readAsJson(s[0]);
+
+                        assertThat(logAsJson)
+                                .containsEntry("Metric2", 1.0)
+                                .containsEntry("Dimension1", "Value1")
+                                .containsKey("_aws");
+
+                        Map<String, Object> aws = (Map<String, Object>) logAsJson.get("_aws");
+
+                        assertThat(aws.get("CloudWatchMetrics"))
+                                .asString()
+                                .contains("Namespace=ExampleApplication");
+
+                        logAsJson = readAsJson(s[1]);
 
                         assertThat(logAsJson)
                                 .containsEntry("Metric1", 1.0)


### PR DESCRIPTION
**Issue #297 

## Description of changes:

Expose another helper utility method to pick default namespace from top level annotation or env var

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics]()

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
