### PR TITLE
feat: Default dimensions from powertools instead of emf library 

### DIFF
--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -108,7 +108,6 @@ if no metrics are provided no exception will be raised. If metrics are provided,
 not met, `ValidationException` exception will be raised.
 
 !!! tip "Metric validation"
-    * Minimum of 1 dimension
     * Maximum of 9 dimensions
 
 If you want to ensure that at least one metric is emitted, you can pass `raiseOnEmptyMetrics = true` to the **@Metrics** annotation:

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -183,6 +183,35 @@ You can use `putMetadata` for advanced use cases, where you want to metadata as 
 
 This will be available in CloudWatch Logs to ease operations on high cardinal data.
 
+## Overriding default dimension set
+
+By default, all metrics emitted via module captures `Service` as one of the default dimension. This is either specified via
+`POWERTOOLS_SERVICE_NAME` environment variable or via `service` attribute on `Metrics` annotation. If you wish to override the default 
+Dimension, it can be done via `#!java MetricsUtils.defaultDimensionSet()`.
+
+=== "App.java"
+
+    ```java hl_lines="8 9 10"
+    import software.amazon.lambda.powertools.metrics.Metrics;
+    import static software.amazon.lambda.powertools.metrics.MetricsUtils;
+    
+    public class App implements RequestHandler<Object, Object> {
+    
+        MetricsLogger metricsLogger = MetricsUtils.metricsLogger();
+        
+        static {
+            MetricsUtils.defaultDimensionSet(DimensionSet.of("CustomDimension", "booking"));
+        }
+    
+        @Override
+        @Metrics(namespace = "ExampleApplication", service = "booking")
+        public Object handleRequest(Object input, Context context) {
+            ...
+            MetricsUtils.withSingleMetric("Metric2", 1, Unit.COUNT, log -> {});
+        }
+    }
+    ```
+
 ## Creating a metric with a different dimension
 
 CloudWatch EMF uses the same dimensions across all your metrics. Use `withSingleMetric` if you have a metric that should have different dimensions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,9 @@ You can use [SAM](https://aws.amazon.com/serverless/sam/) to quickly setup a ser
 
 For more information about the project and available options refer to this [repository](https://github.com/aws-samples/cookiecutter-aws-sam-powertools-java/blob/main/README.md)
 
+!!! note "Using Java 9 or later?"
+    If you are working with lambda function on runtime **Java 9 or later**, please refer **[issue](https://github.com/awslabs/aws-lambda-powertools-java/issues/50)** for a workaround.
+
 === "Maven"
 
     ```xml hl_lines="3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55" 
@@ -98,7 +101,6 @@ For more information about the project and available options refer to this [repo
         </plugins>
     </build>
     ```
-    **Note:** If you are working with lambda function on runtime post java8, please refer [issue](https://github.com/awslabs/aws-lambda-powertools-java/issues/50) for workaround.
 
 === "Gradle"
 

--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -25,6 +25,9 @@ are returned to the queue.
 
 To install this utility, add the following dependency to your project.
 
+!!! note "Using Java 9 or later?"
+    If you are working with lambda function on runtime **Java 9 or later**, please refer **[issue](https://github.com/awslabs/aws-lambda-powertools-java/issues/50)** for a workaround.
+
 === "Maven"
     ```xml hl_lines="3 4 5 6 7 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36"
     <dependencies>

--- a/docs/utilities/sqs_large_message_handling.md
+++ b/docs/utilities/sqs_large_message_handling.md
@@ -34,22 +34,17 @@ This utility is compatible with versions *[1.1.0+](https://github.com/awslabs/am
 To install this utility, add the following dependency to your project.
 
 === "Maven"
-    ```xml
-    <dependency>
-        <groupId>software.amazon.lambda</groupId>
-        <artifactId>powertools-sqs</artifactId>
-        <version>1.3.0</version>
-    </dependency>
-    ```
-
-=== "Maven Configuration"
-
-    Configure the aspectj-maven-plugin to compile-time weave (CTW) the
-    aws-lambda-powertools-java aspects into your project. You may already have this
-    plugin in your pom. In that case add the dependency to the `aspectLibraries`
-    section.
-
-    ```xml hl_lines="13 14 15 16"
+    ```xml hl_lines="3 4 5 6 7 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36"
+    <dependencies>
+        ...
+        <dependency>
+            <groupId>software.amazon.lambda</groupId>
+            <artifactId>powertools-sqs</artifactId>
+            <version>1.3.0</version>
+        </dependency>
+        ...
+    </dependencies>
+    <!-- configure the aspectj-maven-plugin to compile-time weave (CTW) the aws-lambda-powertools-java aspects into your project -->
     <build>
         <plugins>
             ...

--- a/docs/utilities/sqs_large_message_handling.md
+++ b/docs/utilities/sqs_large_message_handling.md
@@ -33,6 +33,9 @@ This utility is compatible with versions *[1.1.0+](https://github.com/awslabs/am
 
 To install this utility, add the following dependency to your project.
 
+!!! note "Using Java 9 or later?"
+If you are working with lambda function on runtime **Java 9 or later**, please refer **[issue](https://github.com/awslabs/aws-lambda-powertools-java/issues/50)** for a workaround.
+
 === "Maven"
     ```xml hl_lines="3 4 5 6 7 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36"
     <dependencies>

--- a/docs/utilities/validation.md
+++ b/docs/utilities/validation.md
@@ -15,23 +15,21 @@ This utility provides JSON Schema validation for payloads held within events and
 
 To install this utility, add the following dependency to your project.
 
+!!! note "Using Java 9 or later?"
+    If you are working with lambda function on runtime **Java 9 or later**, please refer **[issue](https://github.com/awslabs/aws-lambda-powertools-java/issues/50)** for a workaround.
+
 === "Maven"
-    ```xml
+    ```xml hl_lines="3 4 5 6 7 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36"
+    <dependencies>
+    ...
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>powertools-validation</artifactId>
         <version>1.3.0</version>
     </dependency>
-    ```
-
-=== "Maven Configuration"
-
-    Configure the aspectj-maven-plugin to compile-time weave (CTW) the
-    aws-lambda-powertools-java aspects into your project. You may already have this
-    plugin in your pom. In that case add the dependency to the `aspectLibraries`
-    section.
-
-    ```xml hl_lines="13 14 15 16"
+    ...
+    </dependencies>
+    <!-- configure the aspectj-maven-plugin to compile-time weave (CTW) the aws-lambda-powertools-java aspects into your project -->
     <build>
         <plugins>
             ...

--- a/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/internal/LambdaMetricsAspect.java
+++ b/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/internal/LambdaMetricsAspect.java
@@ -23,6 +23,8 @@ import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProce
 import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor.placedOnRequestHandler;
 import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor.placedOnStreamHandler;
 import static software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor.serviceName;
+import static software.amazon.lambda.powertools.metrics.MetricsUtils.defaultDimensionSet;
+import static software.amazon.lambda.powertools.metrics.MetricsUtils.hasDefaultDimension;
 import static software.amazon.lambda.powertools.metrics.MetricsUtils.metricsLogger;
 
 @Aspect
@@ -47,8 +49,9 @@ public class LambdaMetricsAspect {
 
             MetricsLogger logger = metricsLogger();
 
-            logger.setNamespace(namespace(metrics))
-                    .putDimensions(DimensionSet.of("Service", service(metrics)));
+            refreshMetricsContext(metrics);
+
+            logger.setNamespace(namespace(metrics));
 
             extractContext(pjp).ifPresent((context) -> {
                 coldStartSingleMetricIfApplicable(context.getAwsRequestId(), context.getFunctionName(), metrics);
@@ -65,7 +68,7 @@ public class LambdaMetricsAspect {
                 coldStartDone();
                 validateMetricsAndRefreshOnFailure(metrics);
                 logger.flush();
-                refreshMetricsContext();
+                refreshMetricsContext(metrics);
             }
         }
 
@@ -102,7 +105,7 @@ public class LambdaMetricsAspect {
         return !"".equals(metrics.namespace()) ? metrics.namespace() : NAMESPACE;
     }
 
-    private String service(Metrics metrics) {
+    private static String service(Metrics metrics) {
         return !"".equals(metrics.service()) ? metrics.service() : serviceName();
     }
 
@@ -110,17 +113,24 @@ public class LambdaMetricsAspect {
         try {
             validateBeforeFlushingMetrics(metrics);
         } catch (ValidationException e){
-            refreshMetricsContext();
+            refreshMetricsContext(metrics);
             throw e;
         }
     }
 
     // This can be simplified after this issues https://github.com/awslabs/aws-embedded-metrics-java/issues/35 is fixed
-    private static void refreshMetricsContext() {
+    public static void refreshMetricsContext(Metrics metrics) {
         try {
             Field f = metricsLogger().getClass().getDeclaredField("context");
             f.setAccessible(true);
-            f.set(metricsLogger(), new MetricsContext());
+            MetricsContext context = new MetricsContext();
+
+            DimensionSet defaultDimensionSet = hasDefaultDimension() ? defaultDimensionSet()
+                    : DimensionSet.of("Service", service(metrics));
+
+            context.setDefaultDimensions(defaultDimensionSet);
+
+            f.set(metricsLogger(), context);
         } catch (NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }

--- a/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/internal/LambdaMetricsAspect.java
+++ b/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/internal/LambdaMetricsAspect.java
@@ -95,8 +95,8 @@ public class LambdaMetricsAspect {
             throw new ValidationException("No metrics captured, at least one metrics must be emitted");
         }
 
-        if (dimensionsCount() == 0 || dimensionsCount() > 9) {
-            throw new ValidationException(String.format("Number of Dimensions must be in range of 1-9." +
+        if (dimensionsCount() > 9) {
+            throw new ValidationException(String.format("Number of Dimensions must be in range of 0-9." +
                     " Actual size: %d.", dimensionsCount()));
         }
     }

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsEnabledDefaultDimensionHandler.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsEnabledDefaultDimensionHandler.java
@@ -1,0 +1,30 @@
+package software.amazon.lambda.powertools.metrics.handlers;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
+import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
+import software.amazon.cloudwatchlogs.emf.model.Unit;
+import software.amazon.lambda.powertools.metrics.Metrics;
+
+import static software.amazon.lambda.powertools.metrics.MetricsUtils.defaultDimensionSet;
+import static software.amazon.lambda.powertools.metrics.MetricsUtils.metricsLogger;
+import static software.amazon.lambda.powertools.metrics.MetricsUtils.withSingleMetric;
+
+public class PowertoolsMetricsEnabledDefaultDimensionHandler implements RequestHandler<Object, Object> {
+
+    static {
+        defaultDimensionSet(DimensionSet.of("CustomDimension", "booking"));
+    }
+
+    @Override
+    @Metrics(namespace = "ExampleApplication", service = "booking")
+    public Object handleRequest(Object input, Context context) {
+        MetricsLogger metricsLogger = metricsLogger();
+        metricsLogger.putMetric("Metric1", 1, Unit.BYTES);
+
+        withSingleMetric("Metric2", 1, Unit.COUNT, log -> {});
+
+        return null;
+    }
+}

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsNoDimensionsHandler.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/handlers/PowertoolsMetricsNoDimensionsHandler.java
@@ -3,6 +3,7 @@ package software.amazon.lambda.powertools.metrics.handlers;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
+import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.lambda.powertools.metrics.Metrics;
 
 import static software.amazon.lambda.powertools.metrics.MetricsUtils.metricsLogger;
@@ -10,10 +11,11 @@ import static software.amazon.lambda.powertools.metrics.MetricsUtils.metricsLogg
 public class PowertoolsMetricsNoDimensionsHandler implements RequestHandler<Object, Object> {
 
     @Override
-    @Metrics(namespace = "ExampleApplication", service = "booking", captureColdStart = true)
+    @Metrics(namespace = "ExampleApplication", service = "booking")
     public Object handleRequest(Object input, Context context) {
         MetricsLogger metricsLogger = metricsLogger();
-        metricsLogger.setDimensions();
+        metricsLogger.putMetric("CoolMetric", 1);
+        metricsLogger.setDimensions(new DimensionSet());
 
         return null;
     }

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/internal/LambdaMetricsAspectTest.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/internal/LambdaMetricsAspectTest.java
@@ -18,9 +18,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import software.amazon.cloudwatchlogs.emf.config.SystemWrapper;
+import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.lambda.powertools.core.internal.LambdaHandlerProcessor;
+import software.amazon.lambda.powertools.metrics.MetricsUtils;
 import software.amazon.lambda.powertools.metrics.ValidationException;
 import software.amazon.lambda.powertools.metrics.handlers.PowertoolsMetricsColdStartEnabledHandler;
+import software.amazon.lambda.powertools.metrics.handlers.PowertoolsMetricsEnabledDefaultDimensionHandler;
 import software.amazon.lambda.powertools.metrics.handlers.PowertoolsMetricsEnabledHandler;
 import software.amazon.lambda.powertools.metrics.handlers.PowertoolsMetricsEnabledStreamHandler;
 import software.amazon.lambda.powertools.metrics.handlers.PowertoolsMetricsExceptionWhenNoMetricsHandler;
@@ -62,7 +65,6 @@ public class LambdaMetricsAspectTest {
         setupContext();
         writeStaticField(LambdaHandlerProcessor.class, "IS_COLD_START", null, true);
         System.setOut(new PrintStream(out));
-        requestHandler = new PowertoolsMetricsEnabledHandler();
     }
 
     @AfterEach
@@ -78,6 +80,8 @@ public class LambdaMetricsAspectTest {
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
             internalWrapper.when(() -> getenv("_X_AMZN_TRACE_ID")).thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1\"");
 
+            MetricsUtils.defaultDimensionSet(new DimensionSet());
+            requestHandler = new PowertoolsMetricsEnabledHandler();
             requestHandler.handleRequest("input", context);
 
             assertThat(out.toString().split("\n"))
@@ -110,12 +114,56 @@ public class LambdaMetricsAspectTest {
     }
 
     @Test
+    public void metricsWithDefaultDimensionSpecified() {
+        try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class);
+            MockedStatic<software.amazon.lambda.powertools.core.internal.SystemWrapper> internalWrapper = mockStatic(software.amazon.lambda.powertools.core.internal.SystemWrapper.class)) {
+
+            mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
+            internalWrapper.when(() -> getenv("_X_AMZN_TRACE_ID")).thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1\"");
+
+            requestHandler = new PowertoolsMetricsEnabledDefaultDimensionHandler();
+
+            requestHandler.handleRequest("input", context);
+
+            assertThat(out.toString().split("\n"))
+                    .hasSize(2)
+                    .satisfies(s -> {
+                        Map<String, Object> logAsJson = readAsJson(s[0]);
+
+                        assertThat(logAsJson)
+                                .containsEntry("Metric2", 1.0)
+                                .containsEntry("CustomDimension", "booking")
+                                .containsKey("_aws")
+                                .containsEntry("xray_trace_id", "1-5759e988-bd862e3fe1be46a994272793")
+                                .containsEntry("function_request_id", "123ABC");
+
+                        Map<String, Object> aws = (Map<String, Object>) logAsJson.get("_aws");
+
+                        assertThat(aws.get("CloudWatchMetrics"))
+                                .asString()
+                                .contains("Namespace=ExampleApplication");
+
+                        logAsJson = readAsJson(s[1]);
+
+                        assertThat(logAsJson)
+                                .containsEntry("Metric1", 1.0)
+                                .containsEntry("CustomDimension", "booking")
+                                .containsEntry("function_request_id", "123ABC")
+                                .containsKey("_aws");
+                    });
+        }
+    }
+
+    @Test
     public void metricsWithColdStart() {
-        requestHandler = new PowertoolsMetricsColdStartEnabledHandler();
 
         try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class)) {
 
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
+
+            MetricsUtils.defaultDimensionSet(new DimensionSet());
+            requestHandler = new PowertoolsMetricsColdStartEnabledHandler();
+
             requestHandler.handleRequest("input", context);
 
             assertThat(out.toString().split("\n"))
@@ -144,10 +192,13 @@ public class LambdaMetricsAspectTest {
 
     @Test
     public void noColdStartMetricsWhenColdStartDone() {
-        requestHandler = new PowertoolsMetricsColdStartEnabledHandler();
 
         try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class)) {
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
+
+            MetricsUtils.defaultDimensionSet(new DimensionSet());
+            requestHandler = new PowertoolsMetricsColdStartEnabledHandler();
+
             requestHandler.handleRequest("input", context);
             requestHandler.handleRequest("input", context);
 
@@ -186,10 +237,12 @@ public class LambdaMetricsAspectTest {
 
     @Test
     public void metricsWithStreamHandler() throws IOException {
-        streamHandler = new PowertoolsMetricsEnabledStreamHandler();
 
         try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class)) {
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
+
+            MetricsUtils.defaultDimensionSet(new DimensionSet());
+            streamHandler = new PowertoolsMetricsEnabledStreamHandler();
 
             streamHandler.handleRequest(new ByteArrayInputStream(new byte[]{}), new ByteArrayOutputStream(), context);
 
@@ -208,9 +261,11 @@ public class LambdaMetricsAspectTest {
 
     @Test
     public void exceptionWhenNoMetricsEmitted() {
-        requestHandler = new PowertoolsMetricsExceptionWhenNoMetricsHandler();
         try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class)) {
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
+
+            MetricsUtils.defaultDimensionSet(new DimensionSet());
+            requestHandler = new PowertoolsMetricsExceptionWhenNoMetricsHandler();
 
             assertThatExceptionOfType(ValidationException.class)
                     .isThrownBy(() -> requestHandler.handleRequest("input", context))
@@ -220,10 +275,13 @@ public class LambdaMetricsAspectTest {
 
     @Test
     public void noExceptionWhenNoMetricsEmitted() {
-        requestHandler = new PowertoolsMetricsNoExceptionWhenNoMetricsHandler();
 
         try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class)) {
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
+
+            MetricsUtils.defaultDimensionSet(new DimensionSet());
+            requestHandler = new PowertoolsMetricsNoExceptionWhenNoMetricsHandler();
+
             requestHandler.handleRequest("input", context);
 
             assertThat(out.toString())
@@ -239,9 +297,11 @@ public class LambdaMetricsAspectTest {
 
     @Test
     public void exceptionWhenNoDimensionsSet() {
-        requestHandler = new PowertoolsMetricsNoDimensionsHandler();
         try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class)) {
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
+
+            MetricsUtils.defaultDimensionSet(new DimensionSet());
+            requestHandler = new PowertoolsMetricsNoDimensionsHandler();
 
             assertThatExceptionOfType(ValidationException.class)
                     .isThrownBy(() -> requestHandler.handleRequest("input", context))
@@ -251,10 +311,13 @@ public class LambdaMetricsAspectTest {
 
     @Test
     public void exceptionWhenTooManyDimensionsSet() {
-        requestHandler = new PowertoolsMetricsTooManyDimensionsHandler();
 
         try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class)) {
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
+
+            MetricsUtils.defaultDimensionSet(new DimensionSet());
+
+            requestHandler = new PowertoolsMetricsTooManyDimensionsHandler();
 
             assertThatExceptionOfType(ValidationException.class)
                     .isThrownBy(() -> requestHandler.handleRequest("input", context))
@@ -264,9 +327,12 @@ public class LambdaMetricsAspectTest {
 
     @Test
     public void metricsPublishedEvenHandlerThrowsException() {
-        requestHandler = new PowertoolsMetricsWithExceptionInHandler();
         try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class)) {
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
+
+            MetricsUtils.defaultDimensionSet(new DimensionSet());
+            requestHandler = new PowertoolsMetricsWithExceptionInHandler();
+
             assertThatExceptionOfType(IllegalStateException.class)
                     .isThrownBy(() -> requestHandler.handleRequest("input", context))
                     .withMessage("Whoops, unexpected exception");


### PR DESCRIPTION
**Issue #297 #320 
## Description of changes:

Powertools wont capture default dimesion emitted via emf library. By default, it emits following dimensions `"Dimensions":[["LogGroup","ServiceName","ServiceType","Service"]]`.

Now in sync with python version, it will by default emit only `Service`dimension

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics]()

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
