### PR TITLE
Revert "feat: remove deprecated attributes on Tracing annotation"

### DIFF
--- a/powertools-tracing/src/main/java/software/amazon/lambda/powertools/tracing/Tracing.java
+++ b/powertools-tracing/src/main/java/software/amazon/lambda/powertools/tracing/Tracing.java
@@ -33,12 +33,12 @@ import java.lang.annotation.Target;
  * <p>By default {@code Tracing} will capture responses and add them
  * to a sub segment named after the method.</p>
  *
- * <p>To disable this functionality you can specify {@code @Tracing( captureMode = CaptureMode.DISABLED)}</p>
+ * <p>To disable this functionality you can specify {@code @Tracing( captureResponse = false)}</p>
  *
  * <p>By default {@code Tracing} will capture errors and add them
  * to a sub segment named after the method.</p>
  *
- * <p>To disable this functionality you can specify {@code @Tracing( captureMode = CaptureMode.DISABLED)}</p>
+ * <p>To disable this functionality you can specify {@code @Tracing( captureError = false)}</p>
  *e
  * <p>All traces have a namespace set. If {@code @Tracing( namespace = "ExampleService")} is set
  * this takes precedent over any value set in the environment variable {@code POWER_TOOLS_SERVICE_NAME}.
@@ -48,6 +48,20 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 public @interface Tracing {
     String namespace() default "";
+    /**
+     * @deprecated As of release 1.2.0, replaced by captureMode()
+     * in order to support different modes and support via
+     * environment variables
+     */
+    @Deprecated
+    boolean captureResponse() default true;
+    /**
+     * @deprecated As of release 1.2.0, replaced by captureMode()
+     * in order to support different modes and support via
+     * environment variables
+     */
+    @Deprecated
+    boolean captureError() default true;
     String segmentName() default "";
     CaptureMode captureMode() default CaptureMode.ENVIRONMENT_VAR;
 }

--- a/powertools-tracing/src/main/java/software/amazon/lambda/powertools/tracing/internal/LambdaTracingAspect.java
+++ b/powertools-tracing/src/main/java/software/amazon/lambda/powertools/tracing/internal/LambdaTracingAspect.java
@@ -79,7 +79,7 @@ public final class LambdaTracingAspect {
         switch (powerToolsTracing.captureMode()) {
             case ENVIRONMENT_VAR:
                 boolean captureResponse = environmentVariable("POWERTOOLS_TRACER_CAPTURE_RESPONSE");
-                return !isEnvironmentVariableSet("POWERTOOLS_TRACER_CAPTURE_RESPONSE") || captureResponse;
+                return isEnvironmentVariableSet("POWERTOOLS_TRACER_CAPTURE_RESPONSE") ? captureResponse : powerToolsTracing.captureResponse();
             case RESPONSE:
             case RESPONSE_AND_ERROR:
                 return true;
@@ -93,7 +93,7 @@ public final class LambdaTracingAspect {
         switch (powerToolsTracing.captureMode()) {
             case ENVIRONMENT_VAR:
                 boolean captureError = environmentVariable("POWERTOOLS_TRACER_CAPTURE_ERROR");
-                return !isEnvironmentVariableSet("POWERTOOLS_TRACER_CAPTURE_ERROR") || captureError;
+                return isEnvironmentVariableSet("POWERTOOLS_TRACER_CAPTURE_ERROR") ? captureError : powerToolsTracing.captureError();
             case ERROR:
             case RESPONSE_AND_ERROR:
                 return true;

--- a/powertools-tracing/src/test/java/software/amazon/lambda/powertools/tracing/handlers/PowerTracerToolEnabledWithNoMetaDataDeprecated.java
+++ b/powertools-tracing/src/test/java/software/amazon/lambda/powertools/tracing/handlers/PowerTracerToolEnabledWithNoMetaDataDeprecated.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package software.amazon.lambda.powertools.tracing.handlers;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import software.amazon.lambda.powertools.tracing.Tracing;
+
+import static software.amazon.lambda.powertools.tracing.CaptureMode.DISABLED;
+
+public class PowerTracerToolEnabledWithNoMetaDataDeprecated implements RequestHandler<Object, Object> {
+
+    @Override
+    @Tracing(captureResponse = false, captureError = false)
+    public Object handleRequest(Object input, Context context) {
+        return null;
+    }
+}

--- a/powertools-tracing/src/test/java/software/amazon/lambda/powertools/tracing/internal/LambdaTracingAspectTest.java
+++ b/powertools-tracing/src/test/java/software/amazon/lambda/powertools/tracing/internal/LambdaTracingAspectTest.java
@@ -38,6 +38,7 @@ import software.amazon.lambda.powertools.tracing.handlers.PowerTracerToolEnabled
 import software.amazon.lambda.powertools.tracing.handlers.PowerTracerToolEnabledForStreamWithNoMetaData;
 import software.amazon.lambda.powertools.tracing.handlers.PowerTracerToolEnabledWithException;
 import software.amazon.lambda.powertools.tracing.handlers.PowerTracerToolEnabledWithNoMetaData;
+import software.amazon.lambda.powertools.tracing.handlers.PowerTracerToolEnabledWithNoMetaDataDeprecated;
 import software.amazon.lambda.powertools.tracing.nonhandler.PowerToolNonHandler;
 
 import static org.apache.commons.lang3.reflect.FieldUtils.writeStaticField;
@@ -194,6 +195,24 @@ class LambdaTracingAspectTest {
         streamHandler = new PowerTracerToolEnabledForStreamWithNoMetaData();
 
         streamHandler.handleRequest(new ByteArrayInputStream("test".getBytes()), new ByteArrayOutputStream(), context);
+
+        assertThat(AWSXRay.getTraceEntity().getSubsegments())
+                .hasSize(1)
+                .allSatisfy(subsegment -> {
+                    assertThat(subsegment.getAnnotations())
+                            .hasSize(1)
+                            .containsEntry("ColdStart", true);
+
+                    assertThat(subsegment.getMetadata())
+                            .isEmpty();
+                });
+    }
+
+    @Test
+    void shouldCaptureTracesWithNoMetadataDeprecated() {
+        requestHandler = new PowerTracerToolEnabledWithNoMetaDataDeprecated();
+
+        requestHandler.handleRequest(new Object(), context);
 
         assertThat(AWSXRay.getTraceEntity().getSubsegments())
                 .hasSize(1)


### PR DESCRIPTION
Reverts awslabs/aws-lambda-powertools-java#330

We will target removal of deprecated attributes as a separate major release. Ref discussion here https://github.com/awslabs/aws-lambda-powertools-java/pull/345