### PR TITLE
chore(docs): use free fair gradle aspect plugin

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -106,23 +106,22 @@ For more information about the project and available options refer to this [repo
     ```groovy
     plugins{
         id 'java'
-        id 'aspectj.AspectjGradlePlugin' version '0.0.7'
+        id 'io.freefair.aspectj.post-compile-weaving' version '5.0.1'
     }
     repositories {
-        jcenter()
+        mavenCentral()
     }
+
+    aspectj {
+        version  = "1.9.7"
+    }
+
     dependencies {
-        implementation 'software.amazon.lambda:powertools-tracing:1.10.0'
-        aspectpath 'software.amazon.lambda:powertools-tracing:1.10.0'
-        implementation 'software.amazon.lambda:powertools-logging:1.10.0'
-        aspectpath 'software.amazon.lambda:powertools-logging:1.10.0'
-        implementation 'software.amazon.lambda:powertools-metrics:1.10.0'
-        aspectpath 'software.amazon.lambda:powertools-metrics:1.10.0'
+        aspect 'software.amazon.lambda:powertools-logging:1.10.0'
+        aspect 'software.amazon.lambda:powertools-tracing:1.10.0'
+        aspect 'software.amazon.lambda:powertools-metrics:1.10.0'
     }
     ```
-    **Note:**
-    
-    Please add `aspectjVersion = '1.9.6'` to the `gradle.properties` file.
 
 ## Environment variables
 

--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -73,8 +73,7 @@ To install this utility, add the following dependency to your project.
     ```groovy
      dependencies {
         ...
-        implementation 'software.amazon.lambda:powertools-sqs:1.10.0'
-        aspectpath 'software.amazon.lambda:powertools-sqs:1.10.0'
+        aspect 'software.amazon.lambda:powertools-sqs:1.10.0'
     }
     ```
 

--- a/docs/utilities/custom_resources.md
+++ b/docs/utilities/custom_resources.md
@@ -34,7 +34,6 @@ To install this utility, add the following dependency to your project.
      dependencies {
         ...
         implementation 'software.amazon.lambda:powertools-cloudformation:1.10.0'
-        aspectpath 'software.amazon.lambda:powertools-cloudformation:1.10.0'
     }
     ```
 

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -32,8 +32,7 @@ To install this utility, add the following dependency to your project.
     ```groovy
      dependencies {
         ...
-        implementation 'software.amazon.lambda:powertools-parameters:1.10.0'
-        aspectpath 'software.amazon.lambda:powertools-parameters:1.10.0'
+        aspect 'software.amazon.lambda:powertools-parameters:1.10.0'
     }
     ```
 
@@ -425,19 +424,13 @@ If you want to use the ```@Param``` annotation in your project add configuration
     ```groovy
     plugins{
         id 'java'
-        id 'aspectj.AspectjGradlePlugin' version '0.0.6'
+        id 'io.freefair.aspectj.post-compile-weaving' version '5.0.1'
     }
     repositories {
         jcenter()
     }
     dependencies {
         ...
-        implementation 'software.amazon.lambda:powertools-parameters:1.10.0'
-        aspectpath 'software.amazon.lambda:powertools-parameters:1.10.0'
+        aspect 'software.amazon.lambda:powertools-parameters:1.10.0'
     }
     ```
-
-    **Note:**
-    
-    Please add `aspectjVersion = '1.9.6'` to the `gradle.properties` file. The aspectj plugin works at the moment with gradle 5.x only if
-    you are using `java 8` as runtime. Please refer to [open issue](https://github.com/awslabs/aws-lambda-powertools-java/issues/146) for more details.

--- a/docs/utilities/sqs_large_message_handling.md
+++ b/docs/utilities/sqs_large_message_handling.md
@@ -81,8 +81,7 @@ To install this utility, add the following dependency to your project.
     ```groovy
      dependencies {
         ...
-        implementation 'software.amazon.lambda:powertools-sqs:1.10.0'
-        aspectpath 'software.amazon.lambda:powertools-sqs:1.10.0'
+        aspect 'software.amazon.lambda:powertools-sqs:1.10.0'
     }
     ```
 

--- a/docs/utilities/validation.md
+++ b/docs/utilities/validation.md
@@ -62,8 +62,7 @@ To install this utility, add the following dependency to your project.
 
     ```groovy
      dependencies {
-        implementation 'software.amazon.lambda:powertools-validation:1.10.0'
-        aspectpath 'software.amazon.lambda:powertools-validation:1.10.0'
+        aspect 'software.amazon.lambda:powertools-validation:1.10.0'
     }
     ```
 


### PR DESCRIPTION
**Issue #, if available:** https://github.com/awslabs/aws-lambda-powertools-java/issues/146

## Description of changes:

Update docs to use [freefair gradle plugin for aspectj](https://docs.freefair.io/gradle-plugins/5.0.1/reference/#_io_freefair_aspectj_post_compile_weaving). The plugin is actively maintained and works on all gradle versions like 5, 6 and 7

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics]()

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
