### PR TITLE
chore:Prep release 1.10.1

### DIFF
--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -20,3 +20,14 @@ jobs:
           find: ${{ github.event.inputs.previousRelease }}
           replace: ${{ github.event.inputs.targetRelease }}
           regex: false
+          exclude: CHANGELOG.md
+      - name: Create Release Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: chore:prep release ${{ github.event.inputs.targetRelease }}
+          token: ${{ secrets.RELEASE }}
+          signoff: false
+          branch: prep-release-${{ github.event.inputs.targetRelease }}
+          delete-branch: true
+          title: chore:Prep release ${{ github.event.inputs.targetRelease }}
+          body: This is automated release prep. Remember to update [CHANGELOG.md](https://github.com/awslabs/aws-lambda-powertools-java/blob/prep-release-${{ github.event.inputs.targetRelease }}/CHANGELOG.md) to capture changes in this release. Please review changes carefully before merging.

--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ Powertools is available in Maven Central. You can use your favourite dependency 
     <dependency>
         <groupId>software.amazon.lambda</groupId>
         <artifactId>powertools-tracing</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
     </dependency>
     <dependency>
         <groupId>software.amazon.lambda</groupId>
         <artifactId>powertools-logging</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
     </dependency>
     <dependency>
         <groupId>software.amazon.lambda</groupId>
         <artifactId>powertools-metrics</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
     </dependency>
     ...
 </dependencies>

--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -466,7 +466,7 @@ via `samplingRate` attribute on annotation.
 
 ## Upgrade to JsonTemplateLayout from deprecated LambdaJsonLayout configuration in log4j2.xml
 
-Prior to version [1.10.0](https://github.com/awslabs/aws-lambda-powertools-java/releases/tag/v1.10.0), only supported way of configuring `log4j2.xml` was via  `<LambdaJsonLayout/>`. This plugin is 
+Prior to version [1.10.1](https://github.com/awslabs/aws-lambda-powertools-java/releases/tag/v1.10.1), only supported way of configuring `log4j2.xml` was via  `<LambdaJsonLayout/>`. This plugin is 
 deprecated now and will be removed in future version. Switching to `JsonTemplateLayout` is straight forward. 
 
 Below examples shows deprecated and new configuration of `log4j2.xml`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,17 +46,17 @@ For more information about the project and available options refer to this [repo
         <dependency>
             <groupId>software.amazon.lambda</groupId>
             <artifactId>powertools-tracing</artifactId>
-            <version>1.10.0</version>
+            <version>1.10.1</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.lambda</groupId>
             <artifactId>powertools-logging</artifactId>
-            <version>1.10.0</version>
+            <version>1.10.1</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.lambda</groupId>
             <artifactId>powertools-metrics</artifactId>
-            <version>1.10.0</version>
+            <version>1.10.1</version>
         </dependency>
         ...
     </dependencies>
@@ -114,9 +114,9 @@ For more information about the project and available options refer to this [repo
     }
 
     dependencies {
-        aspect 'software.amazon.lambda:powertools-logging:1.10.0'
-        aspect 'software.amazon.lambda:powertools-tracing:1.10.0'
-        aspect 'software.amazon.lambda:powertools-metrics:1.10.0'
+        aspect 'software.amazon.lambda:powertools-logging:1.10.1'
+        aspect 'software.amazon.lambda:powertools-tracing:1.10.1'
+        aspect 'software.amazon.lambda:powertools-metrics:1.10.1'
     }
     ```
 

--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -32,7 +32,7 @@ To install this utility, add the following dependency to your project.
         <dependency>
             <groupId>software.amazon.lambda</groupId>
             <artifactId>powertools-sqs</artifactId>
-            <version>1.10.0</version>
+            <version>1.10.1</version>
         </dependency>
         ...
     </dependencies>
@@ -82,7 +82,7 @@ To install this utility, add the following dependency to your project.
 
     dependencies {
         ...
-        aspect 'software.amazon.lambda:powertools-sqs:1.10.0'
+        aspect 'software.amazon.lambda:powertools-sqs:1.10.1'
     }
     ```
 

--- a/docs/utilities/custom_resources.md
+++ b/docs/utilities/custom_resources.md
@@ -24,7 +24,7 @@ To install this utility, add the following dependency to your project.
     <dependency>
         <groupId>software.amazon.lambda</groupId>
         <artifactId>powertools-cloudformation</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
     </dependency>
     ```
 
@@ -33,7 +33,7 @@ To install this utility, add the following dependency to your project.
     ```groovy
      dependencies {
         ...
-        implementation 'software.amazon.lambda:powertools-cloudformation:1.10.0'
+        implementation 'software.amazon.lambda:powertools-cloudformation:1.10.1'
     }
     ```
 

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -24,7 +24,7 @@ To install this utility, add the following dependency to your project.
     <dependency>
         <groupId>software.amazon.lambda</groupId>
         <artifactId>powertools-parameters</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
     </dependency>
     ```
 === "Gradle"
@@ -32,7 +32,7 @@ To install this utility, add the following dependency to your project.
     ```groovy
      dependencies {
         ...
-        aspect 'software.amazon.lambda:powertools-parameters:1.10.0'
+        aspect 'software.amazon.lambda:powertools-parameters:1.10.1'
     }
     ```
 
@@ -433,6 +433,6 @@ If you want to use the ```@Param``` annotation in your project add configuration
 
     dependencies {
         ...
-        aspect 'software.amazon.lambda:powertools-parameters:1.10.0'
+        aspect 'software.amazon.lambda:powertools-parameters:1.10.1'
     }
     ```

--- a/docs/utilities/sqs_large_message_handling.md
+++ b/docs/utilities/sqs_large_message_handling.md
@@ -40,7 +40,7 @@ To install this utility, add the following dependency to your project.
         <dependency>
             <groupId>software.amazon.lambda</groupId>
             <artifactId>powertools-sqs</artifactId>
-            <version>1.10.0</version>
+            <version>1.10.1</version>
         </dependency>
         ...
     </dependencies>
@@ -90,7 +90,7 @@ To install this utility, add the following dependency to your project.
 
     dependencies {
         ...
-        aspect 'software.amazon.lambda:powertools-sqs:1.10.0'
+        aspect 'software.amazon.lambda:powertools-sqs:1.10.1'
     }
     ```
 

--- a/docs/utilities/validation.md
+++ b/docs/utilities/validation.md
@@ -22,7 +22,7 @@ To install this utility, add the following dependency to your project.
     <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>powertools-validation</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
     </dependency>
     ...
     </dependencies>
@@ -71,7 +71,7 @@ To install this utility, add the following dependency to your project.
     }
 
     dependencies {
-        aspect 'software.amazon.lambda:powertools-validation:1.10.0'
+        aspect 'software.amazon.lambda:powertools-validation:1.10.1'
     }
     ```
 

--- a/example/HelloWorldFunction/build.gradle
+++ b/example/HelloWorldFunction/build.gradle
@@ -8,23 +8,23 @@ repositories {
 }
 
 dependencies {
-    implementation 'software.amazon.lambda:powertools-tracing:1.10.0'
-    aspectpath 'software.amazon.lambda:powertools-tracing:1.10.0'
+    implementation 'software.amazon.lambda:powertools-tracing:1.10.1'
+    aspectpath 'software.amazon.lambda:powertools-tracing:1.10.1'
 
-    implementation 'software.amazon.lambda:powertools-logging:1.10.0'
-    aspectpath 'software.amazon.lambda:powertools-logging:1.10.0'
+    implementation 'software.amazon.lambda:powertools-logging:1.10.1'
+    aspectpath 'software.amazon.lambda:powertools-logging:1.10.1'
 
-    implementation 'software.amazon.lambda:powertools-metrics:1.10.0'
-    aspectpath 'software.amazon.lambda:powertools-metrics:1.10.0'
+    implementation 'software.amazon.lambda:powertools-metrics:1.10.1'
+    aspectpath 'software.amazon.lambda:powertools-metrics:1.10.1'
 
-    implementation 'software.amazon.lambda:powertools-sqs:1.10.0'
-    aspectpath 'software.amazon.lambda:powertools-sqs:1.10.0'
+    implementation 'software.amazon.lambda:powertools-sqs:1.10.1'
+    aspectpath 'software.amazon.lambda:powertools-sqs:1.10.1'
 
-    implementation 'software.amazon.lambda:powertools-parameters:1.10.0'
-    aspectpath 'software.amazon.lambda:powertools-parameters:1.10.0'
+    implementation 'software.amazon.lambda:powertools-parameters:1.10.1'
+    aspectpath 'software.amazon.lambda:powertools-parameters:1.10.1'
 
-    implementation 'software.amazon.lambda:powertools-validation:1.10.0'
-    aspectpath 'software.amazon.lambda:powertools-validation:1.10.0'
+    implementation 'software.amazon.lambda:powertools-validation:1.10.1'
+    aspectpath 'software.amazon.lambda:powertools-validation:1.10.1'
 
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     implementation 'com.amazonaws:aws-lambda-java-events:3.1.0'

--- a/example/HelloWorldFunction/pom.xml
+++ b/example/HelloWorldFunction/pom.xml
@@ -16,32 +16,32 @@
         <dependency>
             <groupId>software.amazon.lambda</groupId>
             <artifactId>powertools-tracing</artifactId>
-            <version>1.10.0</version>
+            <version>1.10.1</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.lambda</groupId>
             <artifactId>powertools-logging</artifactId>
-            <version>1.10.0</version>
+            <version>1.10.1</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.lambda</groupId>
             <artifactId>powertools-metrics</artifactId>
-            <version>1.10.0</version>
+            <version>1.10.1</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.lambda</groupId>
             <artifactId>powertools-parameters</artifactId>
-            <version>1.10.0</version>
+            <version>1.10.1</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.lambda</groupId>
             <artifactId>powertools-validation</artifactId>
-            <version>1.10.0</version>
+            <version>1.10.1</version>
         </dependency>
         <dependency>
             <groupId>software.amazon.lambda</groupId>
             <artifactId>powertools-sqs</artifactId>
-            <version>1.10.0</version>
+            <version>1.10.1</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>software.amazon.lambda</groupId>
     <artifactId>powertools-parent</artifactId>
-    <version>1.10.0</version>
+    <version>1.10.1</version>
     <packaging>pom</packaging>
 
     <name>AWS Lambda Powertools Java library Parent</name>

--- a/powertools-cloudformation/pom.xml
+++ b/powertools-cloudformation/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
     </parent>
 
     <name>AWS Lambda Powertools Java library Cloudformation</name>

--- a/powertools-core/pom.xml
+++ b/powertools-core/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
     </parent>
 
     <name>AWS Lambda Powertools Java library Core</name>

--- a/powertools-logging/pom.xml
+++ b/powertools-logging/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
     </parent>
 
     <name>AWS Lambda Powertools Java library Logging</name>

--- a/powertools-metrics/pom.xml
+++ b/powertools-metrics/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
     </parent>
 
     <name>AWS Lambda Powertools Java library Metrics</name>

--- a/powertools-parameters/pom.xml
+++ b/powertools-parameters/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
     </parent>
 
     <artifactId>powertools-parameters</artifactId>

--- a/powertools-sqs/pom.xml
+++ b/powertools-sqs/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
     </parent>
 
     <name>AWS Lambda Powertools Java library SQS</name>

--- a/powertools-test-suite/pom.xml
+++ b/powertools-test-suite/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
     </parent>
 
     <name>AWS Lambda Powertools Java library Test Suite</name>

--- a/powertools-tracing/pom.xml
+++ b/powertools-tracing/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
     </parent>
 
     <name>AWS Lambda Powertools Java library Tracing</name>

--- a/powertools-validation/pom.xml
+++ b/powertools-validation/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>powertools-parent</artifactId>
         <groupId>software.amazon.lambda</groupId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
     </parent>
 
     <name>AWS Lambda Powertools Java validation library</name>


### PR DESCRIPTION
This is automated release prep. Remember to update [CHANGELOG.md](https://github.com/awslabs/aws-lambda-powertools-java/blob/prep-release-1.10.1/CHANGELOG.md) to capture changes in this release. Please review changes carefully before merging.