### PR TITLE
fix(gradle): Fix gradle example and docs to work with java 12+

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -117,9 +117,6 @@ For more information about the project and available options refer to this [repo
         aspect 'software.amazon.lambda:powertools-logging:{{ powertools.version }}'
         aspect 'software.amazon.lambda:powertools-tracing:{{ powertools.version }}'
         aspect 'software.amazon.lambda:powertools-metrics:{{ powertools.version }}'
-        implementation 'software.amazon.lambda:powertools-logging:{{ powertools.version }}'
-        implementation 'software.amazon.lambda:powertools-tracing:{{ powertools.version }}'
-        implementation 'software.amazon.lambda:powertools-metrics:{{ powertools.version }}'
     }
 
     sourceCompatibility = 11

--- a/docs/index.md
+++ b/docs/index.md
@@ -117,7 +117,13 @@ For more information about the project and available options refer to this [repo
         aspect 'software.amazon.lambda:powertools-logging:{{ powertools.version }}'
         aspect 'software.amazon.lambda:powertools-tracing:{{ powertools.version }}'
         aspect 'software.amazon.lambda:powertools-metrics:{{ powertools.version }}'
+        implementation 'software.amazon.lambda:powertools-logging:{{ powertools.version }}'
+        implementation 'software.amazon.lambda:powertools-tracing:{{ powertools.version }}'
+        implementation 'software.amazon.lambda:powertools-metrics:{{ powertools.version }}'
     }
+
+    sourceCompatibility = 11
+    targetCompatibility = 11
     ```
 
 ## Environment variables

--- a/example/HelloWorldFunction/build.gradle
+++ b/example/HelloWorldFunction/build.gradle
@@ -1,6 +1,6 @@
 plugins{
     id 'java'
-    id 'aspectj.AspectjGradlePlugin' version '0.0.7'
+    id 'io.freefair.aspectj.post-compile-weaving' version '6.3.0'
 }
 
 repositories {
@@ -8,23 +8,19 @@ repositories {
 }
 
 dependencies {
+    aspect 'software.amazon.lambda:powertools-logging:1.10.2'
+    aspect 'software.amazon.lambda:powertools-tracing:1.10.2'
+    aspect 'software.amazon.lambda:powertools-metrics:1.10.2'
+    aspect 'software.amazon.lambda:powertools-sqs:1.10.2'
+    aspect 'software.amazon.lambda:powertools-parameters:1.10.2'
+    aspect 'software.amazon.lambda:powertools-validation:1.10.2'
+
     implementation 'software.amazon.lambda:powertools-tracing:1.10.2'
-    aspectpath 'software.amazon.lambda:powertools-tracing:1.10.2'
-
     implementation 'software.amazon.lambda:powertools-logging:1.10.2'
-    aspectpath 'software.amazon.lambda:powertools-logging:1.10.2'
-
     implementation 'software.amazon.lambda:powertools-metrics:1.10.2'
-    aspectpath 'software.amazon.lambda:powertools-metrics:1.10.2'
-
     implementation 'software.amazon.lambda:powertools-sqs:1.10.2'
-    aspectpath 'software.amazon.lambda:powertools-sqs:1.10.2'
-
     implementation 'software.amazon.lambda:powertools-parameters:1.10.2'
-    aspectpath 'software.amazon.lambda:powertools-parameters:1.10.2'
-
     implementation 'software.amazon.lambda:powertools-validation:1.10.2'
-    aspectpath 'software.amazon.lambda:powertools-validation:1.10.2'
 
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     implementation 'com.amazonaws:aws-lambda-java-events:3.1.0'
@@ -32,5 +28,8 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-api:2.16.0'
     implementation 'org.apache.logging.log4j:log4j-core:2.16.0'
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
 }
+
+sourceCompatibility = 11
+targetCompatibility = 11

--- a/example/HelloWorldFunction/build.gradle
+++ b/example/HelloWorldFunction/build.gradle
@@ -15,13 +15,6 @@ dependencies {
     aspect 'software.amazon.lambda:powertools-parameters:1.10.2'
     aspect 'software.amazon.lambda:powertools-validation:1.10.2'
 
-    implementation 'software.amazon.lambda:powertools-tracing:1.10.2'
-    implementation 'software.amazon.lambda:powertools-logging:1.10.2'
-    implementation 'software.amazon.lambda:powertools-metrics:1.10.2'
-    implementation 'software.amazon.lambda:powertools-sqs:1.10.2'
-    implementation 'software.amazon.lambda:powertools-parameters:1.10.2'
-    implementation 'software.amazon.lambda:powertools-validation:1.10.2'
-
     implementation 'com.amazonaws:aws-lambda-java-core:1.2.1'
     implementation 'com.amazonaws:aws-lambda-java-events:3.1.0'
 

--- a/example/HelloWorldFunction/gradle/wrapper/gradle-wrapper.properties
+++ b/example/HelloWorldFunction/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/example/HelloWorldFunction/pom.xml
+++ b/example/HelloWorldFunction/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION

**Issue #, if available:**

closes #702

## Description of changes:

Changes:
- Bump gradle version to 7.3.3
- Use `io.freefair.aspectj.post-compile-weaving` in example project
- Specify java 11 for sourceCompatibility, targetCompatibility
- Bump junit version to 4.13.2

closes #702

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics]()

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
