### PR TITLE
fix(docs): fix title for custom resources page

### DIFF
--- a/docs/utilities/custom_resources.md
+++ b/docs/utilities/custom_resources.md
@@ -1,5 +1,6 @@
 ---
-title: Custom Resources description: Utility
+title: Custom Resources 
+description: Utility
 ---
 
 [Custom resources](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources.html)


### PR DESCRIPTION
**Issue #, if available:**

There is a rendering issue with the docs for custom resources

<img width="1384" alt="Screen Shot 2022-02-18 at 3 47 00 PM" src="https://user-images.githubusercontent.com/5442469/154775567-2a7328d0-09c0-4540-a4a0-66a61e53319f.png">

## Description of changes:

Fix the formatting of the header info

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics]()

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
