### PR TITLE
Documentation: Changed project name for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AWS Lambda Powertools (Java)
+# AWS Lambda Powertools for Java
 
 ![aws provider](https://img.shields.io/badge/provider-AWS-orange?logo=amazon-aws&color=ff9900) ![Build status](https://github.com/awslabs/aws-lambda-powertools-java/actions/workflows/build.yml/badge.svg) ![Maven Central](https://img.shields.io/maven-central/v/software.amazon.lambda/powertools-parent)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Homepage
-description: AWS Lambda Powertools Java
+description: AWS Lambda Powertools for Java
 ---
 
 ![aws provider](https://img.shields.io/badge/provider-AWS-orange?logo=amazon-aws&color=ff9900) ![Build status](https://github.com/awslabs/aws-lambda-powertools-java/actions/workflows/build.yml/badge.svg) ![Maven Central](https://img.shields.io/maven-central/v/software.amazon.lambda/powertools-parent)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Lambda Powertools Java
+site_name: AWS Lambda Powertools for Java
 site_description: AWS Lambda Powertools for Java
 site_author: Amazon Web Services
 nav:

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>1.12.0</version>
     <packaging>pom</packaging>
 
-    <name>AWS Lambda Powertools Java library Parent</name>
+    <name>AWS Lambda Powertools for Java library Parent</name>
     <description>
         A suite of utilities for AWS Lambda Functions that makes tracing with AWS X-Ray, structured logging and creating custom metrics asynchronously easier.
     </description>

--- a/powertools-cloudformation/pom.xml
+++ b/powertools-cloudformation/pom.xml
@@ -13,7 +13,7 @@
         <version>1.12.0</version>
     </parent>
 
-    <name>AWS Lambda Powertools Java library Cloudformation</name>
+    <name>AWS Lambda Powertools for Java library Cloudformation</name>
     <description>
         A suite of utilities for AWS Lambda Functions that makes tracing with AWS X-Ray, structured logging and creating
         custom metrics asynchronously easier.

--- a/powertools-core/pom.xml
+++ b/powertools-core/pom.xml
@@ -13,7 +13,7 @@
         <version>1.12.0</version>
     </parent>
 
-    <name>AWS Lambda Powertools Java library Core</name>
+    <name>AWS Lambda Powertools for Java library Core</name>
     <description>
         A suite of utilities for AWS Lambda Functions that makes tracing with AWS X-Ray, structured logging and creating custom metrics asynchronously easier.
     </description>

--- a/powertools-idempotency/pom.xml
+++ b/powertools-idempotency/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>powertools-idempotency</artifactId>
     <packaging>jar</packaging>
 
-    <name>AWS Lambda Powertools Java library Idempotency</name>
+    <name>AWS Lambda Powertools for Java library Idempotency</name>
     <description>
 
     </description>

--- a/powertools-logging/pom.xml
+++ b/powertools-logging/pom.xml
@@ -13,7 +13,7 @@
         <version>1.12.0</version>
     </parent>
 
-    <name>AWS Lambda Powertools Java library Logging</name>
+    <name>AWS Lambda Powertools for Java library Logging</name>
     <description>
         A suite of utilities for AWS Lambda Functions that makes tracing with AWS X-Ray, structured logging and creating custom metrics asynchronously easier.
     </description>

--- a/powertools-metrics/pom.xml
+++ b/powertools-metrics/pom.xml
@@ -13,7 +13,7 @@
         <version>1.12.0</version>
     </parent>
 
-    <name>AWS Lambda Powertools Java library Metrics</name>
+    <name>AWS Lambda Powertools for Java library Metrics</name>
     <description>
         A suite of utilities for AWS Lambda Functions that make creating custom metrics via AWS Embedded Metric Format
         asynchronously easier.

--- a/powertools-parameters/pom.xml
+++ b/powertools-parameters/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>powertools-parameters</artifactId>
 
-    <name>AWS Lambda Powertools Java library Parameters</name>
+    <name>AWS Lambda Powertools for Java library Parameters</name>
 
     <description>
         Set of utilities to retrieve parameters from Secrets Manager or SSM Parameter Store

--- a/powertools-serialization/pom.xml
+++ b/powertools-serialization/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>powertools-serialization</artifactId>
     <packaging>jar</packaging>
 
-    <name>AWS Lambda Powertools Java library Serialization Utilities</name>
+    <name>AWS Lambda Powertools for Java library Serialization Utilities</name>
     <description>
 
     </description>

--- a/powertools-sqs/pom.xml
+++ b/powertools-sqs/pom.xml
@@ -13,7 +13,7 @@
         <version>1.12.0</version>
     </parent>
 
-    <name>AWS Lambda Powertools Java library SQS</name>
+    <name>AWS Lambda Powertools for Java library SQS</name>
     <description>
         A suite of utilities for AWS Lambda Functions that makes tracing with AWS X-Ray, structured logging and creating custom metrics asynchronously easier.
     </description>

--- a/powertools-test-suite/pom.xml
+++ b/powertools-test-suite/pom.xml
@@ -13,7 +13,7 @@
         <version>1.12.0</version>
     </parent>
 
-    <name>AWS Lambda Powertools Java library Test Suite</name>
+    <name>AWS Lambda Powertools for Java library Test Suite</name>
     <description>
         A suite of tests for interactions between the various Powertools modules.
     </description>

--- a/powertools-tracing/pom.xml
+++ b/powertools-tracing/pom.xml
@@ -13,7 +13,7 @@
         <version>1.12.0</version>
     </parent>
 
-    <name>AWS Lambda Powertools Java library Tracing</name>
+    <name>AWS Lambda Powertools for Java library Tracing</name>
     <description>
         A suite of utilities for AWS Lambda Functions that makes tracing with AWS X-Ray, structured logging and creating custom metrics asynchronously easier.
     </description>

--- a/powertools-validation/pom.xml
+++ b/powertools-validation/pom.xml
@@ -13,7 +13,7 @@
         <version>1.12.0</version>
     </parent>
 
-    <name>AWS Lambda Powertools Java validation library</name>
+    <name>AWS Lambda Powertools for Java validation library</name>
     <description>
         Json schema validation for Lambda events and responses
     </description>


### PR DESCRIPTION
**Issue #, if available: #779**

## Description of changes:

Searched through repo to find instances of project name being any of the following:
- AWS Lambda Powertools (Java)
- Lambda Powertools Java
- AWS Lambda Powertools Java

Changed each instance to "AWS Lambda Powertools for Java".
<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics]()

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
