### PR TITLE
fix: disable idempotency doesn't disable dynamodb client creation in persistent store

### DIFF
--- a/powertools-idempotency/src/main/java/software/amazon/lambda/powertools/idempotency/internal/IdempotentAspect.java
+++ b/powertools-idempotency/src/main/java/software/amazon/lambda/powertools/idempotency/internal/IdempotentAspect.java
@@ -47,7 +47,7 @@ public class IdempotentAspect {
                          Idempotent idempotent) throws Throwable {
 
         String idempotencyDisabledEnv = System.getenv().get(Constants.IDEMPOTENCY_DISABLED_ENV);
-        if (idempotencyDisabledEnv != null && !idempotencyDisabledEnv.equals("false")) {
+        if (idempotencyDisabledEnv != null && !idempotencyDisabledEnv.equalsIgnoreCase("false")) {
             return pjp.proceed(pjp.getArgs());
         }
 

--- a/powertools-idempotency/src/main/java/software/amazon/lambda/powertools/idempotency/persistence/DynamoDBPersistenceStore.java
+++ b/powertools-idempotency/src/main/java/software/amazon/lambda/powertools/idempotency/persistence/DynamoDBPersistenceStore.java
@@ -78,11 +78,18 @@ public class DynamoDBPersistenceStore extends BasePersistenceStore implements Pe
         if (client != null) {
             this.dynamoDbClient = client;
         } else {
-            DynamoDbClientBuilder ddbBuilder = DynamoDbClient.builder()
-                    .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
-                    .httpClient(UrlConnectionHttpClient.builder().build())
-                    .region(Region.of(System.getenv(AWS_REGION_ENV)));
-            this.dynamoDbClient = ddbBuilder.build();
+            String idempotencyDisabledEnv = System.getenv().get(Constants.IDEMPOTENCY_DISABLED_ENV);
+            if (idempotencyDisabledEnv == null || idempotencyDisabledEnv.equals("false")) {
+                DynamoDbClientBuilder ddbBuilder = DynamoDbClient.builder()
+                        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                        .httpClient(UrlConnectionHttpClient.builder().build())
+                        .region(Region.of(System.getenv(AWS_REGION_ENV)));
+                this.dynamoDbClient = ddbBuilder.build();
+            } else {
+                // we do not want to create a DynamoDbClient if idempotency is disabled
+                // null is ok as idempotency won't be called
+                this.dynamoDbClient = null;
+            }
         }
     }
 

--- a/powertools-idempotency/src/main/java/software/amazon/lambda/powertools/idempotency/persistence/DynamoDBPersistenceStore.java
+++ b/powertools-idempotency/src/main/java/software/amazon/lambda/powertools/idempotency/persistence/DynamoDBPersistenceStore.java
@@ -79,7 +79,7 @@ public class DynamoDBPersistenceStore extends BasePersistenceStore implements Pe
             this.dynamoDbClient = client;
         } else {
             String idempotencyDisabledEnv = System.getenv().get(Constants.IDEMPOTENCY_DISABLED_ENV);
-            if (idempotencyDisabledEnv == null || idempotencyDisabledEnv.equals("false")) {
+            if (idempotencyDisabledEnv == null || idempotencyDisabledEnv.equalsIgnoreCase("false")) {
                 DynamoDbClientBuilder ddbBuilder = DynamoDbClient.builder()
                         .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
                         .httpClient(UrlConnectionHttpClient.builder().build())

--- a/powertools-idempotency/src/test/java/software/amazon/lambda/powertools/idempotency/persistence/DynamoDBPersistenceStoreTest.java
+++ b/powertools-idempotency/src/test/java/software/amazon/lambda/powertools/idempotency/persistence/DynamoDBPersistenceStoreTest.java
@@ -16,7 +16,9 @@ package software.amazon.lambda.powertools.idempotency.persistence;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import software.amazon.awssdk.services.dynamodb.model.*;
+import software.amazon.lambda.powertools.idempotency.Constants;
 import software.amazon.lambda.powertools.idempotency.DynamoDBConfig;
 import software.amazon.lambda.powertools.idempotency.IdempotencyConfig;
 import software.amazon.lambda.powertools.idempotency.exceptions.IdempotencyItemAlreadyExistsException;
@@ -258,6 +260,13 @@ public class DynamoDBPersistenceStoreTest extends DynamoDBConfig {
                 // OK
             }
         }
+    }
+
+    @Test
+    @SetEnvironmentVariable(key = Constants.IDEMPOTENCY_DISABLED_ENV, value = "true")
+    public void idempotencyDisabled_noClientShouldBeCreated() {
+        DynamoDBPersistenceStore store = DynamoDBPersistenceStore.builder().withTableName(TABLE_NAME).build();
+        assertThatThrownBy(() -> store.getRecord("fake")).isInstanceOf(NullPointerException.class);
     }
 
     @BeforeEach


### PR DESCRIPTION
**Issue #, if available:**
When disabling idempotency using the environment variable "`POWERTOOLS_IDEMPOTENCY_DISABLED`", the creation of the `DynamoDbClient` was not disabled, which is not desired when performing tests (it tries to connect to AWS or requires to setup a local dynamodb)

## Description of changes:
When using the "`POWERTOOLS_IDEMPOTENCY_DISABLED`" env var, the `DynamoDbClient` (for the idempotency module) is not created.


**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics]()

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
