### PR TITLE
docs(governance): new form to allow customers self-nominate as public reference

### DIFF
--- a/.github/ISSUE_TEMPLATE/support_powertools.yml
+++ b/.github/ISSUE_TEMPLATE/support_powertools.yml
@@ -1,0 +1,64 @@
+name: Support Lambda Powertools (become a reference)
+description: Add your organization's name or logo to the Lambda Powertools documentation
+title: "[Support Lambda Powertools]: <your organization name>"
+labels: ["customer_reference"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for becoming a reference customer. Your support means a lot to us. It also helps new customers to know who's using it.
+
+        If you would like us to also display your organization's logo, please share a link in the `Company logo` field.
+  - type: input
+    id: organization
+    attributes:
+      label: Organization Name
+      description: Please share the name of your organization
+      placeholder: ACME
+    validations:
+      required: true
+  - type: input
+    id: name
+    attributes:
+      label: Your Name
+      description: Please share your name
+    validations:
+      required: true
+  - type: input
+    id: job
+    attributes:
+      label: Your current position
+      description: Please share your current position at your company
+    validations:
+      required: true
+  - type: input
+    id: logo
+    attributes:
+      label: (Optional) Company logo
+      description: Company logo you want us to display. You also allow us to resize for optimal placement in the documentation.
+    validations:
+      required: false
+  - type: textarea
+    id: use_case
+    attributes:
+      label: (Optional) Use case
+      description: How are you using Lambda Powertools today? *features, etc.*
+    validations:
+      required: false
+  - type: checkboxes
+    id: other_languages
+    attributes:
+      label: Also using other Lambda Powertools languages?
+      options:
+        - label: Python
+          required: false
+        - label: TypeScript
+          required: false
+        - label: .NET
+          required: false
+  - type: markdown
+    attributes:
+      value: |
+        *By raising a Support Lambda Powertools issue, you are granting AWS permission to use your company's name (and/or logo) for the limited purpose described here. You are also confirming that you have authority to grant such permission.*
+
+        *You can opt-out at any time by commenting or reopening this issue.*


### PR DESCRIPTION
**Issue #, if available:**
n/a
## Description of changes:
This marks a new milestone where we can accept public references via GitHub 🎉
<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics]()

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
