### PR TITLE
fix: envelope is not taken into account with built-in types

### DIFF
--- a/powertools-validation/pom.xml
+++ b/powertools-validation/pom.xml
@@ -75,6 +75,10 @@
             <artifactId>json-schema-validator</artifactId>
             <version>1.0.73</version>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-serialization</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>
@@ -87,11 +91,7 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-lambda-java-serialization</artifactId>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>

--- a/powertools-validation/src/main/java/software/amazon/lambda/powertools/validation/ValidationUtils.java
+++ b/powertools-validation/src/main/java/software/amazon/lambda/powertools/validation/ValidationUtils.java
@@ -76,7 +76,7 @@ public class ValidationUtils {
             Expression<JsonNode> expression = ValidationConfig.get().getJmesPath().compile(envelope);
             subNode = expression.search(jsonNode);
             if (subNode == null || subNode instanceof NullNode) {
-                throw new ValidationException("Not found");
+                throw new ValidationException("Envelope not found in the object");
             }
         } catch (Exception e) {
             throw new ValidationException("Cannot find envelope <"+envelope+"> in the object <"+obj+">", e);

--- a/powertools-validation/src/main/java/software/amazon/lambda/powertools/validation/internal/ValidationAspect.java
+++ b/powertools-validation/src/main/java/software/amazon/lambda/powertools/validation/internal/ValidationAspect.java
@@ -40,7 +40,6 @@ import static software.amazon.lambda.powertools.validation.ValidationUtils.valid
 public class ValidationAspect {
     private static final Logger LOG = LoggerFactory.getLogger(ValidationAspect.class);
 
-
     @SuppressWarnings({"EmptyMethod"})
     @Pointcut("@annotation(validation)")
     public void callAt(Validation validation) {

--- a/powertools-validation/src/main/java/software/amazon/lambda/powertools/validation/internal/ValidationAspect.java
+++ b/powertools-validation/src/main/java/software/amazon/lambda/powertools/validation/internal/ValidationAspect.java
@@ -122,9 +122,7 @@ public class ValidationAspect {
         if (validationNeeded && !validation.outboundSchema().isEmpty()) {
             JsonSchema outboundJsonSchema = getJsonSchema(validation.outboundSchema(), true);
 
-            if (validation.envelope() != null && !validation.envelope().isEmpty()) {
-                validate(result, outboundJsonSchema, validation.envelope());
-            } else if (result instanceof APIGatewayProxyResponseEvent) {
+            if (result instanceof APIGatewayProxyResponseEvent) {
                 APIGatewayProxyResponseEvent response = (APIGatewayProxyResponseEvent) result;
                 validate(response.getBody(), outboundJsonSchema);
             } else if (result instanceof APIGatewayV2HTTPResponse) {

--- a/powertools-validation/src/main/java/software/amazon/lambda/powertools/validation/internal/ValidationAspect.java
+++ b/powertools-validation/src/main/java/software/amazon/lambda/powertools/validation/internal/ValidationAspect.java
@@ -19,6 +19,8 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.lambda.powertools.validation.Validation;
 import software.amazon.lambda.powertools.validation.ValidationConfig;
 
@@ -36,6 +38,9 @@ import static software.amazon.lambda.powertools.validation.ValidationUtils.valid
  */
 @Aspect
 public class ValidationAspect {
+    private static final Logger LOG = LoggerFactory.getLogger(ValidationAspect.class);
+
+
     @SuppressWarnings({"EmptyMethod"})
     @Pointcut("@annotation(validation)")
     public void callAt(Validation validation) {
@@ -59,7 +64,9 @@ public class ValidationAspect {
                 JsonSchema inboundJsonSchema = getJsonSchema(validation.inboundSchema(), true);
 
                 Object obj = pjp.getArgs()[0];
-                if (obj instanceof APIGatewayProxyRequestEvent) {
+                if (validation.envelope() != null && !validation.envelope().isEmpty()) {
+                    validate(obj, inboundJsonSchema, validation.envelope());
+                } else if (obj instanceof APIGatewayProxyRequestEvent) {
                     APIGatewayProxyRequestEvent event = (APIGatewayProxyRequestEvent) obj;
                     validate(event.getBody(), inboundJsonSchema);
                 } else if (obj instanceof APIGatewayV2HTTPEvent) {
@@ -105,7 +112,7 @@ public class ValidationAspect {
                     KinesisAnalyticsStreamsInputPreprocessingEvent event = (KinesisAnalyticsStreamsInputPreprocessingEvent) obj;
                     event.getRecords().forEach(record -> validate(decode(record.getData()), inboundJsonSchema));
                 } else {
-                    validate(obj, inboundJsonSchema, validation.envelope());
+                    LOG.warn("Unhandled event type {}, please use the 'envelope' parameter to specify what to validate", obj.getClass().getName());
                 }
             }
         }
@@ -115,7 +122,9 @@ public class ValidationAspect {
         if (validationNeeded && !validation.outboundSchema().isEmpty()) {
             JsonSchema outboundJsonSchema = getJsonSchema(validation.outboundSchema(), true);
 
-            if (result instanceof APIGatewayProxyResponseEvent) {
+            if (validation.envelope() != null && !validation.envelope().isEmpty()) {
+                validate(result, outboundJsonSchema, validation.envelope());
+            } else if (result instanceof APIGatewayProxyResponseEvent) {
                 APIGatewayProxyResponseEvent response = (APIGatewayProxyResponseEvent) result;
                 validate(response.getBody(), outboundJsonSchema);
             } else if (result instanceof APIGatewayV2HTTPResponse) {
@@ -131,7 +140,7 @@ public class ValidationAspect {
                 KinesisAnalyticsInputPreprocessingResponse response = (KinesisAnalyticsInputPreprocessingResponse) result;
                 response.getRecords().forEach(record -> validate(decode(record.getData()), outboundJsonSchema));
             } else {
-                validate(result, outboundJsonSchema, validation.envelope());
+                LOG.warn("Unhandled response type {}, please use the 'envelope' parameter to specify what to validate", result.getClass().getName());
             }
         }
 

--- a/powertools-validation/src/test/java/software/amazon/lambda/powertools/validation/handlers/SQSWithCustomEnvelopeHandler.java
+++ b/powertools-validation/src/test/java/software/amazon/lambda/powertools/validation/handlers/SQSWithCustomEnvelopeHandler.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package software.amazon.lambda.powertools.validation.handlers;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import software.amazon.lambda.powertools.validation.Validation;
+
+public class SQSWithCustomEnvelopeHandler implements RequestHandler<SQSEvent, String> {
+
+    @Override
+    @Validation(inboundSchema = "classpath:/schema_v7.json", envelope = "records[*].powertools_json(body).powertools_json(Message)")
+    public String handleRequest(SQSEvent input, Context context) {
+        return "OK";
+    }
+}

--- a/powertools-validation/src/test/java/software/amazon/lambda/powertools/validation/handlers/SQSWithWrongEnvelopeHandler.java
+++ b/powertools-validation/src/test/java/software/amazon/lambda/powertools/validation/handlers/SQSWithWrongEnvelopeHandler.java
@@ -18,10 +18,11 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import software.amazon.lambda.powertools.validation.Validation;
 
-public class SQSWithCustomEnvelopeHandler implements RequestHandler<SQSEvent, String> {
+public class SQSWithWrongEnvelopeHandler implements RequestHandler<SQSEvent, String> {
 
     @Override
-    @Validation(inboundSchema = "classpath:/schema_v7.json", envelope = "Records[*].powertools_json(body).powertools_json(Message)")
+    // real event contains Records with big R (https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html)
+    @Validation(inboundSchema = "classpath:/schema_v7.json", envelope = "records[*].powertools_json(body).powertools_json(Message)")
     public String handleRequest(SQSEvent input, Context context) {
         return "OK";
     }

--- a/powertools-validation/src/test/java/software/amazon/lambda/powertools/validation/internal/ValidationAspectTest.java
+++ b/powertools-validation/src/test/java/software/amazon/lambda/powertools/validation/internal/ValidationAspectTest.java
@@ -102,6 +102,15 @@ public class ValidationAspectTest {
     }
 
     @Test
+    public void validate_SQS_CustomEnvelopeTakePrecedence() {
+        PojoSerializer<SQSEvent> pojoSerializer = LambdaEventSerializers.serializerFor(SQSEvent.class, ClassLoader.getSystemClassLoader());
+        SQSEvent event = pojoSerializer.fromJson(this.getClass().getResourceAsStream("/sqs_message.json"));
+
+        SQSWithCustomEnvelopeHandler handler = new SQSWithCustomEnvelopeHandler();
+        assertThat(handler.handleRequest(event, context)).isEqualTo("OK");
+    }
+
+    @Test
     public void validate_Kinesis() {
         PojoSerializer<KinesisEvent> pojoSerializer = LambdaEventSerializers.serializerFor(KinesisEvent.class, ClassLoader.getSystemClassLoader());
         KinesisEvent event = pojoSerializer.fromJson(this.getClass().getResourceAsStream("/kinesis.json"));

--- a/powertools-validation/src/test/java/software/amazon/lambda/powertools/validation/internal/ValidationAspectTest.java
+++ b/powertools-validation/src/test/java/software/amazon/lambda/powertools/validation/internal/ValidationAspectTest.java
@@ -111,6 +111,15 @@ public class ValidationAspectTest {
     }
 
     @Test
+    public void validate_SQS_WrongEnvelope_shouldThrowValidationException() {
+        PojoSerializer<SQSEvent> pojoSerializer = LambdaEventSerializers.serializerFor(SQSEvent.class, ClassLoader.getSystemClassLoader());
+        SQSEvent event = pojoSerializer.fromJson(this.getClass().getResourceAsStream("/sqs_message.json"));
+
+        SQSWithWrongEnvelopeHandler handler = new SQSWithWrongEnvelopeHandler();
+        assertThatExceptionOfType(ValidationException.class).isThrownBy(() -> handler.handleRequest(event, context));
+    }
+
+    @Test
     public void validate_Kinesis() {
         PojoSerializer<KinesisEvent> pojoSerializer = LambdaEventSerializers.serializerFor(KinesisEvent.class, ClassLoader.getSystemClassLoader());
         KinesisEvent event = pojoSerializer.fromJson(this.getClass().getResourceAsStream("/kinesis.json"));

--- a/powertools-validation/src/test/resources/sqs_message.json
+++ b/powertools-validation/src/test/resources/sqs_message.json
@@ -1,0 +1,22 @@
+{
+  "Records": [
+    {
+      "messageId": "d9144555-9a4f-4ec3-99a0-fc4e625a8db2",
+      "receiptHandle": "7kam5bfzbDsjtcjElvhSbxeLJbeey3A==",
+      "body": "{\n \"Message\": \"{\\n  \\\"id\\\": 43242,\\n  \\\"name\\\": \\\"FooBar XY\\\",\\n  \\\"price\\\": 258\\n}\"}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1601975709495",
+        "SenderId": "AROAIFU457DVZ5L2J53F2",
+        "ApproximateFirstReceiveTimestamp": "1601975709499"
+      },
+      "messageAttributes": {
+
+      },
+      "md5OfBody": "0f96e88a291edb4429f2f7b9fdc3df96",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:eu-central-1:123456789012:TestLambda",
+      "awsRegion": "eu-central-1"
+    }
+  ]
+}


### PR DESCRIPTION
**Issue #, if available:** #959

## Description of changes:
When an envelope is set, it takes precedence over the built-in types. If not set, built-in types validation apply. If the type is not handled, a warn is logged.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics]()

## Breaking change checklist

People using an envelope with a built-in type (useless) may now enter in the envelope validation rather than the built-in one, causing validation error.

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
