### PR TITLE
fix: compilation warning with SqsLargeMessageAspect on gradle

### DIFF
--- a/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspect.java
+++ b/powertools-logging/src/main/java/software/amazon/lambda/powertools/logging/internal/LambdaLoggingAspect.java
@@ -58,7 +58,7 @@ import static software.amazon.lambda.powertools.logging.LoggingUtils.appendKeys;
 import static software.amazon.lambda.powertools.logging.LoggingUtils.objectMapper;
 
 @Aspect
-@DeclarePrecedence("*, SqsLargeMessageAspect, LambdaLoggingAspect")
+@DeclarePrecedence("*, software.amazon.lambda.powertools.logging.internal.LambdaLoggingAspect")
 public final class LambdaLoggingAspect {
     private static final Logger LOG = LogManager.getLogger(LambdaLoggingAspect.class);
     private static final Random SAMPLER = new Random();


### PR DESCRIPTION
**Issue #, if available:** #945
`SqsLargeMessageAspect` is not necessarily in the classpath, which cause an issue (warning during compilation) with gradle

## Description of changes:
- remove SqsLargeMessageAspect in DeclarePrecedence in Logging Module:
  - The * before `LambdaLoggingAspect` includes `SqsLargeMessageAspect`

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [] Update tests
* [] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

