### PR TITLE
feat(metrics): introduce  MetricsUtils.withMetricsLogger utility

### DIFF
--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -234,3 +234,27 @@ CloudWatch EMF uses the same dimensions across all your metrics. Use `withSingle
         }
     }
     ```
+
+## Creating metrics with different configurations
+
+Use `withMetric` if you have one or more metrics that should have different configurations e.g. dimensions or namespace.
+
+=== "App.java"
+
+    ```java hl_lines="7 8 9 10 11 12 13" 
+    import static software.amazon.lambda.powertools.metrics.MetricsUtils.withSingleMetric;
+
+    public class App implements RequestHandler<Object, Object> {
+
+        @Override
+        public Object handleRequest(Object input, Context context) {
+             withMetric(metric -> {
+                // override default dimensions
+                metric.setDimensions(DimensionSet.of("AnotherService", "CustomService"));
+                // add metrics
+                metric.putMetric("CustomMetrics1", 1, Unit.COUNT);
+                metric.putMetric("CustomMetrics2", 5, Unit.COUNT);
+            });
+        }
+    }
+    ```

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -242,7 +242,7 @@ Use `withMetric` if you have one or more metrics that should have different conf
 === "App.java"
 
     ```java hl_lines="7 8 9 10 11 12 13" 
-    import static software.amazon.lambda.powertools.metrics.MetricsUtils.withSingleMetric;
+    import static software.amazon.lambda.powertools.metrics.MetricsUtils.withMetric;
 
     public class App implements RequestHandler<Object, Object> {
 

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -242,18 +242,18 @@ Use `withMetric` if you have one or more metrics that should have different conf
 === "App.java"
 
     ```java hl_lines="7 8 9 10 11 12 13" 
-    import static software.amazon.lambda.powertools.metrics.MetricsUtils.withMetric;
+    import static software.amazon.lambda.powertools.metrics.MetricsUtils.withMetricsLogger;
 
     public class App implements RequestHandler<Object, Object> {
 
         @Override
         public Object handleRequest(Object input, Context context) {
-             withMetric(metric -> {
+             withMetricsLogger(logger -> {
                 // override default dimensions
-                metric.setDimensions(DimensionSet.of("AnotherService", "CustomService"));
+                logger.setDimensions(DimensionSet.of("AnotherService", "CustomService"));
                 // add metrics
-                metric.putMetric("CustomMetrics1", 1, Unit.COUNT);
-                metric.putMetric("CustomMetrics2", 5, Unit.COUNT);
+                logger.putMetric("CustomMetrics1", 1, Unit.COUNT);
+                logger.putMetric("CustomMetrics2", 5, Unit.COUNT);
             });
         }
     }

--- a/docs/core/metrics.md
+++ b/docs/core/metrics.md
@@ -237,7 +237,7 @@ CloudWatch EMF uses the same dimensions across all your metrics. Use `withSingle
 
 ## Creating metrics with different configurations
 
-Use `withMetric` if you have one or more metrics that should have different configurations e.g. dimensions or namespace.
+Use `withMetricsLogger` if you have one or more metrics that should have different configurations e.g. dimensions or namespace.
 
 === "App.java"
 

--- a/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/MetricsUtils.java
+++ b/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/MetricsUtils.java
@@ -121,6 +121,26 @@ public final class MetricsUtils {
         }
     }
 
+    /**
+     * Provide and immediately flush a {@link MetricsLogger}. It will use the default namespace
+     * specified either on {@link Metrics} annotation or via POWERTOOLS_METRICS_NAMESPACE env var.
+     * It by default captures function_request_id as property if used together with {@link Metrics} annotation. It will also
+     * capture xray_trace_id as property if tracing is enabled.
+     *
+     * @param logger the MetricsLogger
+     */
+    public static void withMetric(final Consumer<MetricsLogger> logger) {
+        MetricsLogger metricsLogger = logger();
+
+        try {
+            metricsLogger.setNamespace(defaultNameSpace());
+            captureRequestAndTraceId(metricsLogger);
+            logger.accept(metricsLogger);
+        } finally {
+            metricsLogger.flush();
+        }
+    }
+
     public static DimensionSet[] getDefaultDimensions() {
         return Arrays.copyOf(defaultDimensions, defaultDimensions.length);
     }

--- a/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/MetricsUtils.java
+++ b/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/MetricsUtils.java
@@ -81,16 +81,10 @@ public final class MetricsUtils {
                                         final double value,
                                         final Unit unit,
                                         final Consumer<MetricsLogger> logger) {
-        MetricsLogger metricsLogger = logger();
-
-        try {
-            metricsLogger.setNamespace(defaultNameSpace());
+        withMetric(metricsLogger -> {
             metricsLogger.putMetric(name, value, unit);
-            captureRequestAndTraceId(metricsLogger);
             logger.accept(metricsLogger);
-        } finally {
-            metricsLogger.flush();
-        }
+        });
     }
 
     /**
@@ -109,16 +103,11 @@ public final class MetricsUtils {
                                         final Unit unit,
                                         final String namespace,
                                         final Consumer<MetricsLogger> logger) {
-        MetricsLogger metricsLogger = logger();
-
-        try {
+        withMetric(metricsLogger -> {
             metricsLogger.setNamespace(namespace);
             metricsLogger.putMetric(name, value, unit);
-            captureRequestAndTraceId(metricsLogger);
             logger.accept(metricsLogger);
-        } finally {
-            metricsLogger.flush();
-        }
+        });
     }
 
     /**

--- a/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/MetricsUtils.java
+++ b/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/MetricsUtils.java
@@ -81,7 +81,7 @@ public final class MetricsUtils {
                                         final double value,
                                         final Unit unit,
                                         final Consumer<MetricsLogger> logger) {
-        withMetric(metricsLogger -> {
+        withMetricLogger(metricsLogger -> {
             metricsLogger.putMetric(name, value, unit);
             logger.accept(metricsLogger);
         });
@@ -103,7 +103,7 @@ public final class MetricsUtils {
                                         final Unit unit,
                                         final String namespace,
                                         final Consumer<MetricsLogger> logger) {
-        withMetric(metricsLogger -> {
+        withMetricLogger(metricsLogger -> {
             metricsLogger.setNamespace(namespace);
             metricsLogger.putMetric(name, value, unit);
             logger.accept(metricsLogger);
@@ -111,14 +111,14 @@ public final class MetricsUtils {
     }
 
     /**
-     * Provide and immediately flush a {@link MetricsLogger}. It will use the default namespace
+     * Provide and immediately flush a {@link MetricsLogger}. It uses the default namespace
      * specified either on {@link Metrics} annotation or via POWERTOOLS_METRICS_NAMESPACE env var.
      * It by default captures function_request_id as property if used together with {@link Metrics} annotation. It will also
      * capture xray_trace_id as property if tracing is enabled.
      *
      * @param logger the MetricsLogger
      */
-    public static void withMetric(final Consumer<MetricsLogger> logger) {
+    public static void withMetricLogger(final Consumer<MetricsLogger> logger) {
         MetricsLogger metricsLogger = logger();
 
         try {

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/MetricsLoggerTest.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/MetricsLoggerTest.java
@@ -6,7 +6,6 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,9 +15,9 @@ import software.amazon.cloudwatchlogs.emf.config.SystemWrapper;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
 
-import static java.util.Collections.*;
-import static org.assertj.core.api.Assertions.*;
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.mockito.Mockito.mockStatic;
 import static software.amazon.lambda.powertools.core.internal.SystemWrapper.getenv;
 
@@ -124,14 +123,14 @@ class MetricsLoggerTest {
     }
 
     @Test
-    void metricsCaptureUtilityWithDefaultNameSpace() {
+    void metricsLoggerCaptureUtilityWithDefaultNameSpace() {
         try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class);
              MockedStatic<software.amazon.lambda.powertools.core.internal.SystemWrapper> internalWrapper = mockStatic(software.amazon.lambda.powertools.core.internal.SystemWrapper.class)) {
             mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
             mocked.when(() -> SystemWrapper.getenv("POWERTOOLS_METRICS_NAMESPACE")).thenReturn("GlobalName");
             internalWrapper.when(() -> getenv("_X_AMZN_TRACE_ID")).thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1\"");
 
-            MetricsUtils.withMetric(metricsLogger -> {
+            MetricsUtils.withMetricLogger(metricsLogger -> {
                 metricsLogger.setDimensions(DimensionSet.of("Dimension1", "Value1"));
                 metricsLogger.putMetric("Metric1", 1, Unit.COUNT);
             });

--- a/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/MetricsLoggerTest.java
+++ b/powertools-metrics/src/test/java/software/amazon/lambda/powertools/metrics/MetricsLoggerTest.java
@@ -124,6 +124,38 @@ class MetricsLoggerTest {
     }
 
     @Test
+    void metricsCaptureUtilityWithDefaultNameSpace() {
+        try (MockedStatic<SystemWrapper> mocked = mockStatic(SystemWrapper.class);
+             MockedStatic<software.amazon.lambda.powertools.core.internal.SystemWrapper> internalWrapper = mockStatic(software.amazon.lambda.powertools.core.internal.SystemWrapper.class)) {
+            mocked.when(() -> SystemWrapper.getenv("AWS_EMF_ENVIRONMENT")).thenReturn("Lambda");
+            mocked.when(() -> SystemWrapper.getenv("POWERTOOLS_METRICS_NAMESPACE")).thenReturn("GlobalName");
+            internalWrapper.when(() -> getenv("_X_AMZN_TRACE_ID")).thenReturn("Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1\"");
+
+            MetricsUtils.withMetric(metricsLogger -> {
+                metricsLogger.setDimensions(DimensionSet.of("Dimension1", "Value1"));
+                metricsLogger.putMetric("Metric1", 1, Unit.COUNT);
+            });
+
+            assertThat(out.toString())
+                    .satisfies(s -> {
+                        Map<String, Object> logAsJson = readAsJson(s);
+
+                        assertThat(logAsJson)
+                                .containsEntry("Metric1", 1.0)
+                                .containsEntry("Dimension1", "Value1")
+                                .containsKey("_aws")
+                                .containsEntry("xray_trace_id", "1-5759e988-bd862e3fe1be46a994272793");
+
+                        Map<String, Object> aws = (Map<String, Object>) logAsJson.get("_aws");
+
+                        assertThat(aws.get("CloudWatchMetrics"))
+                                .asString()
+                                .contains("Namespace=GlobalName");
+                    });
+        }
+    }
+
+    @Test
     void shouldThrowExceptionWhenDefaultDimensionIsNull() {
         assertThatNullPointerException()
                 .isThrownBy(() -> MetricsUtils.defaultDimensionSet(null))


### PR DESCRIPTION
closes #999

**Issue #, if available:** #999

## Description of changes:

introduce new `MetricsUtils.withMetricsLogger` utility method to enable higher level of customization to the metrics logger and eliminate the need to know the metric/configuration when calling the method and leave that instead to the `Consumer<MetricsLogger>`

The main use case my team has
1. We're emitting a number of metrics - ~10 metrics - that all have the same config (e.g. dimensions) that's meant to be different from `MetricsUtils.metricsLogger()` i.e. we need a new metrics logger instance
2. The names of those metrics are generated dynamically - think loops, appending different constants - to generate those names

So, ideally, we create a new instance of a metrics logger, and then rely on to emit those 10 different metrics.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [x] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
