### PR TITLE
Bump Mockito to latest compatible version.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     labels:
       - "maven"
       - "dependencies"
+    ignore:
+      # Ignore Mockito 5.X.X as it does not support Java 8
+      - dependency-name: mockito-*
+        update-types: ["version-update:semver-major"]

--- a/pom.xml
+++ b/pom.xml
@@ -244,13 +244,13 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>4.9.0</version>
+                <version>4.11.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-inline</artifactId>
-                <version>4.9.0</version>
+                <version>4.11.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION


**Issue #, if available:**

Bump manually Mockito to latest supported version (4.11.0).
Configure dependabot to avoid bumping Mockito to v. 5 as it requires Java 11.



---------
<!--- One or two sentences as a summary of what's being changed -->

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
