### PR TITLE
chore(ci): add workflow to dispatch analytics fetching

### DIFF
--- a/.github/workflows/dispatch_analytics.yml
+++ b/.github/workflows/dispatch_analytics.yml
@@ -1,0 +1,43 @@
+name: Dispatch analytics
+
+on:
+  workflow_dispatch:
+
+  schedule:
+    - cron: '0 * * * *'
+
+permissions:
+  id-token: write
+  actions: read
+  checks: read
+  contents: read
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+
+jobs:
+  dispatch_token:
+    concurrency:
+      group: analytics
+    runs-on: ubuntu-latest
+    environment: analytics
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef
+        with:
+          aws-region: eu-central-1
+          role-to-assume: ${{ secrets.AWS_ANALYTICS_ROLE_ARN }}
+
+      - name: Invoke Lambda function
+        run: |
+          payload=$(echo -n '{"githubToken": "${{ secrets.GITHUB_TOKEN }}"}' | base64)
+          aws lambda invoke \
+            --function-name ${{ secrets.AWS_ANALYTICS_DISPATCHER_ARN }} \
+            --payload "$payload" response.json
+          cat response.json


### PR DESCRIPTION
**Issue #, if available:** #1142

## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

This PR adds a new GitHub action workflow that runs every hour, and uses the GITHUB_TOKEN to dispatch the crawling of the analytics data.

In order to merge this we'll need:

- create a new GitHub environment called "analytics"
- inside that new environment, create two new secrets (please contact me on Slack for the values):
  - AWS_ANALYTICS_ROLE_ARN
  - AWS_ANALYTICS_DISPATCHER_ARN

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
