### PR TITLE
fix:Removing env var credentials provider as default.

### DIFF
--- a/powertools-idempotency/src/main/java/software/amazon/lambda/powertools/idempotency/persistence/DynamoDBPersistenceStore.java
+++ b/powertools-idempotency/src/main/java/software/amazon/lambda/powertools/idempotency/persistence/DynamoDBPersistenceStore.java
@@ -86,7 +86,6 @@ public class DynamoDBPersistenceStore extends BasePersistenceStore implements Pe
             String idempotencyDisabledEnv = System.getenv().get(Constants.IDEMPOTENCY_DISABLED_ENV);
             if (idempotencyDisabledEnv == null || idempotencyDisabledEnv.equalsIgnoreCase("false")) {
                 DynamoDbClientBuilder ddbBuilder = DynamoDbClient.builder()
-                        .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
                         .httpClient(UrlConnectionHttpClient.builder().build())
                         .region(Region.of(System.getenv(AWS_REGION_ENV)));
                 this.dynamoDbClient = ddbBuilder.build();
@@ -236,6 +235,10 @@ public class DynamoDBPersistenceStore extends BasePersistenceStore implements Pe
                 data != null ? data.s() : null,
                 validation != null ? validation.s() : null,
                 item.get(this.inProgressExpiryAttr) != null ? OptionalLong.of(Long.parseLong(item.get(this.inProgressExpiryAttr).n())) : OptionalLong.empty());
+    }
+
+    public DynamoDbClient getDynamoDbClient() {
+        return dynamoDbClient;
     }
 
     public static Builder builder() {


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/awslabs/aws-lambda-powertools-java/issues/1160

## Description of changes:
SnapStart uses a different credentials provider to on-demand, so when it is hardcoded like this, the default will fail.

I think our default settings should first work will both SnapStart and on-demand before they are optimised for one. If anyone disagrees, lets have a discussion.

Testing this is difficult, the configuration isn't an open attribute, so I don't think I can write a unit test easily (please let me know if I'm wrong). An integration test seems overkill.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
