### PR TITLE
docs:  update groupId in Maven dependency of powertools-validation

### DIFF
--- a/docs/utilities/validation.md
+++ b/docs/utilities/validation.md
@@ -20,7 +20,7 @@ To install this utility, add the following dependency to your project.
     <dependencies>
     ...
     <dependency>
-        <groupId>com.amazonaws</groupId>
+        <groupId>software.amazon.lambda</groupId>
         <artifactId>powertools-validation</artifactId>
         <version>{{ powertools.version }}</version>
     </dependency>


### PR DESCRIPTION
Fix goupId of Maven dependency

**Issue #, if available:**

## Description of changes:

The `<groupId>` in the Maven example isn't correct and doesn't match the `<groupId>` in the `<plugin><aspectLibraries>`.  Checking Maven Central, I've confirmed that `<groupId> software.amazon.lambda</groupId>` is the correct group.  This PR is to fix the errant dependency.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [ ] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [ ] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
