### PR TITLE
chore: rename project from Powertools to Powertools for AWS Lambda (Java)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,7 +34,7 @@ assignees: ''
 
 ## Environment
 
-* **Powertools version used**:
+* **Powertools for AWS Lambda (Java) version used**:
 * **Packaging format (Layers, Maven/Gradle)**:
 * **AWS Lambda function runtime:**
 * **Debugging logs**

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -55,9 +55,9 @@ body:
     attributes:
       label: Acknowledgment
       options:
-        - label: This request meets [Lambda Powertools Tenets](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
+        - label: This request meets [Powertools for AWS Lambda (Java) Tenets](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
           required: true
-        - label: Should this be considered in other Lambda Powertools languages? i.e. [Python](https://github.com/awslabs/aws-lambda-powertools-python/), [TypeScript](https://github.com/awslabs/aws-lambda-powertools-typescript/)
+        - label: Should this be considered in other Powertools for AWS Lambda (Java) languages? i.e. [Python](https://github.com/awslabs/aws-lambda-powertools-python/), [TypeScript](https://github.com/awslabs/aws-lambda-powertools-typescript/)
           required: false
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/rfc.md
+++ b/.github/ISSUE_TEMPLATE/rfc.md
@@ -29,7 +29,7 @@ assignees: ''
 
 > This is the bulk of the RFC.
 
-> Explain the design in enough detail for somebody familiar with Powertools to understand it, and for somebody familiar with the implementation to implement it.
+> Explain the design in enough detail for somebody familiar with Powertools for AWS Lambda (Java) to understand it, and for somebody familiar with the implementation to implement it.
 
 > This should get into specifics and corner-cases, and include examples of how the feature is used. Any new terminology should be defined here.
 

--- a/.github/ISSUE_TEMPLATE/share_your_work.yml
+++ b/.github/ISSUE_TEMPLATE/share_your_work.yml
@@ -1,5 +1,5 @@
 name: I Made This (showcase your work)
-description: Share what you did with Powertools 💞💞. Blog post, workshops, presentation, sample apps, etc.
+description: Share what you did with Powertools for AWS Lambda (Java) 💞💞. Blog post, workshops, presentation, sample apps, etc.
 title: "[I Made This]: <TITLE>"
 labels: ["community-content"]
 body:
@@ -13,7 +13,7 @@ body:
       description: |
         Please share the original link to your material.
 
-        *Note: Short links will be expanded when added to Powertools documentation*
+        *Note: Short links will be expanded when added to Powertools for AWS Lambda (Java) documentation*
     validations:
       required: true
   - type: textarea
@@ -44,7 +44,7 @@ body:
       description: |
         Any notes you might want to share with us related to this material.
 
-        *Note: These notes are explicitly to Powertools maintainers. It will not be added to the community resources page.*
+        *Note: These notes are explicitly to Powertools for AWS Lambda (Java) maintainers. It will not be added to the community resources page.*
     validations:
       required: false
   - type: checkboxes
@@ -52,5 +52,5 @@ body:
     attributes:
       label: Acknowledgment
       options:
-        - label: I understand this content may be removed from Powertools documentation if it doesn't conform with the [Code of Conduct](https://aws.github.io/code-of-conduct)
+        - label: I understand this content may be removed from Powertools for AWS Lambda (Java) documentation if it doesn't conform with the [Code of Conduct](https://aws.github.io/code-of-conduct)
           required: true

--- a/.github/ISSUE_TEMPLATE/support_powertools.yml
+++ b/.github/ISSUE_TEMPLATE/support_powertools.yml
@@ -1,6 +1,6 @@
-name: Support Lambda Powertools (become a reference)
-description: Add your organization's name or logo to the Lambda Powertools documentation
-title: "[Support Lambda Powertools]: <your organization name>"
+name: Support Powertools for AWS Lambda (Java) (become a reference)
+description: Add your organization's name or logo to the Powertools for AWS Lambda (Java) documentation
+title: "[Support Powertools for AWS Lambda (Java)]: <your organization name>"
 labels: ["customer_reference"]
 body:
   - type: markdown
@@ -42,13 +42,13 @@ body:
     id: use_case
     attributes:
       label: (Optional) Use case
-      description: How are you using Lambda Powertools today? *features, etc.*
+      description: How are you using Powertools for AWS Lambda (Java) today? *features, etc.*
     validations:
       required: false
   - type: checkboxes
     id: other_languages
     attributes:
-      label: Also using other Lambda Powertools languages?
+      label: Also using other Powertools for AWS Lambda (Java) languages?
       options:
         - label: Python
           required: false
@@ -59,6 +59,6 @@ body:
   - type: markdown
     attributes:
       value: |
-        *By raising a Support Lambda Powertools issue, you are granting AWS permission to use your company's name (and/or logo) for the limited purpose described here. You are also confirming that you have authority to grant such permission.*
+        *By raising a Support Powertools for AWS Lambda (Java) issue, you are granting AWS permission to use your company's name (and/or logo) for the limited purpose described here. You are also confirming that you have authority to grant such permission.*
 
         *You can opt-out at any time by commenting or reopening this issue.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) fo
 ### Documentation
 
 * Improve `powertools-cloudformation` docs (#1090) by @mriccia
-* Add link to Lambda powertools workshop (#1095) by @scottgerring
+* Add link to Powertools for AWS Lambda (Java) workshop (#1095) by @scottgerring
 * Fix mdocs and git revision plugin integration (#1066) by @machafer
 
 
@@ -42,7 +42,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) fo
 
 ### Documentation
 
-* Docs: Update PowerTools definition by @heitorlessa
+* Docs: Update Powertools for AWS Lambda (Java) definition by @heitorlessa
 * Docs: Add information about other supported langauges to README and docs (#1033) by @kozub
 
 ## [1.13.0] - 2022-12-14
@@ -101,8 +101,8 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) fo
 ## [1.11.0] - 2022-02-16
 
 ### Added
- * Powertools Idempotency module: New module to get your Lambda function [Idempotent](https://aws.amazon.com/builders-library/making-retries-safe-with-idempotent-APIs/) (#717)
- * Powertools Serialization module: New module to handle JSON (de)serialization (Jackson ObjectMapper, JMESPath functions)
+ * Powertools for AWS Lambda (Java) Idempotency module: New module to get your Lambda function [Idempotent](https://aws.amazon.com/builders-library/making-retries-safe-with-idempotent-APIs/) (#717)
+ * Powertools for AWS Lambda (Java) Serialization module: New module to handle JSON (de)serialization (Jackson ObjectMapper, JMESPath functions)
 
 
 ## [1.10.3] - 2022-02-01
@@ -151,7 +151,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) fo
 
 ### Added
 
-* **Powertools Cloudformation module (NEW)**: New module simplifying [AWS Lambda-backed custom resources](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources-lambda.html) written in Java. [#560](https://github.com/awslabs/aws-lambda-powertools-java/pull/560)
+* **Powertools for AWS Lambda (Java) Cloudformation module (NEW)**: New module simplifying [AWS Lambda-backed custom resources](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources-lambda.html) written in Java. [#560](https://github.com/awslabs/aws-lambda-powertools-java/pull/560)
 * **SQS Large message processing**: Ability to override the default `S3Client` use to fetch payload from S3. [#602](https://github.com/awslabs/aws-lambda-powertools-java/pull/602)
 
 ### Regression
@@ -168,14 +168,14 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) fo
 
 ## [1.7.2] - 2021-08-03
 
-* **Powertools All Modules**: Upgrade to the latest(1.14.0) aspectj-maven-plugin which also supports Java 9 and newer versions. 
+* **Powertools for AWS Lambda (Java) All Modules**: Upgrade to the latest(1.14.0) aspectj-maven-plugin which also supports Java 9 and newer versions. 
 Users no longer need to depend on [com.nickwongdev](https://mvnrepository.com/artifact/com.nickwongdev/aspectj-maven-plugin/1.12.6) as a workaround. [#489](https://github.com/awslabs/aws-lambda-powertools-java/pull/489)
 * **Logging**: Performance optimisation to improve cold start. [#484](https://github.com/awslabs/aws-lambda-powertools-java/pull/484)
 * **SQS Batch processing/Large message**: Module now lazy loads default SQS client. [#484](https://github.com/awslabs/aws-lambda-powertools-java/pull/484)
 
 ## [1.7.1] - 2021-07-06
 
-* **Powertools All Modules**: Fix static code analysis violations done via [spotbugs](https://github.com/spotbugs/spotbugs) ([#458](https://github.com/awslabs/aws-lambda-powertools-java/pull/458)).
+* **Powertools for AWS Lambda (Java) All Modules**: Fix static code analysis violations done via [spotbugs](https://github.com/spotbugs/spotbugs) ([#458](https://github.com/awslabs/aws-lambda-powertools-java/pull/458)).
 
 ## [1.7.0] - 2021-07-05
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# AWS Lambda Powertools for Java
+# Powertools for AWS Lambda (Java)
 
 ![aws provider](https://img.shields.io/badge/provider-AWS-orange?logo=amazon-aws&color=ff9900) ![Build status](https://github.com/awslabs/aws-lambda-powertools-java/actions/workflows/build.yml/badge.svg) ![Maven Central](https://img.shields.io/maven-central/v/software.amazon.lambda/powertools-parent) [![codecov.io](https://codecov.io/github/awslabs/aws-lambda-powertools-java/branch/master/graphs/badge.svg)](https://app.codecov.io/gh/awslabs/aws-lambda-powertools-java)
 
 
-Powertools is a developer toolkit to implement Serverless best practices and increase developer velocity.
+Powertools for AWS Lambda (Java) is a developer toolkit to implement Serverless best practices and increase developer velocity.
 
 > Also available in [Python](https://github.com/awslabs/aws-lambda-powertools-python), [TypeScript](https://github.com/awslabs/aws-lambda-powertools-typescript), and [.NET](https://github.com/awslabs/aws-lambda-powertools-dotnet).
 
@@ -11,7 +11,7 @@ Powertools is a developer toolkit to implement Serverless best practices and inc
 
 ### Installation
 
-Powertools is available in Maven Central. You can use your favourite dependency management tool to install it
+Powertools for AWS Lambda (Java) is available in Maven Central. You can use your favourite dependency management tool to install it
 
 * [maven](https://maven.apache.org/):
 ```xml

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -4,7 +4,7 @@ description: Frequently Asked Questions
 ---
 
 
-## How can I use Powertools with Lombok?
+## How can I use Powertools for AWS Lambda (Java) with Lombok?
 
 Poweretools uses `aspectj-maven-plugin` to compile-time weave (CTW) aspects into the project. In case you want to use `Lombok` or other compile-time preprocessor for your project, it is required to change `aspectj-maven-plugin` configuration to enable in-place weaving feature. Otherwise the plugin will ignore changes introduced by `Lombok` and will use `.java` files as a source. 
 
@@ -27,7 +27,7 @@ To enable in-place weaving feature you need to use following `aspectj-maven-plug
 </configuration>
 ```
 
-## How can I use Powertools with Kotlin projects?
+## How can I use Powertools for AWS Lambda (Java) with Kotlin projects?
 
 Poweretools uses `aspectj-maven-plugin` to compile-time weave (CTW) aspects into the project. When using it with Kotlin projects, it is required to `forceAjcCompile`. 
 No explicit configuration should be required for gradle projects. 

--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -13,7 +13,7 @@ Logging provides an opinionated logger with output structured as JSON.
 
 ## Initialization
 
-Powertools extends the functionality of Log4J. Below is an example `#!xml log4j2.xml` file, with the `JsonTemplateLayout` using `#!json LambdaJsonLayout.json` configured. 
+Powertools for AWS Lambda (Java) extends the functionality of Log4J. Below is an example `#!xml log4j2.xml` file, with the `JsonTemplateLayout` using `#!json LambdaJsonLayout.json` configured. 
 
 !!! info "LambdaJsonLayout is now deprecated"
 

--- a/docs/core/tracing.md
+++ b/docs/core/tracing.md
@@ -37,12 +37,12 @@ Before your use this utility, your AWS Lambda function [must have permissions](h
                     POWERTOOLS_SERVICE_NAME: example
     ```
 
-The Powertools service name is used as the X-Ray namespace. This can be set using the environment variable
+The Powertools for AWS Lambda (Java) service name is used as the X-Ray namespace. This can be set using the environment variable
 `POWERTOOLS_SERVICE_NAME`
 
 ### Lambda handler
 
-To enable Powertools tracing to your function add the `@Tracing` annotation to your `handleRequest` method or on
+To enable Powertools for AWS Lambda (Java) tracing to your function add the `@Tracing` annotation to your `handleRequest` method or on
 any method will capture the method as a separate subsegment automatically. You can optionally choose to customize 
 segment name that appears in traces.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,19 +1,19 @@
 ---
 title: Homepage
-description: AWS Lambda Powertools for Java
+description: Powertools for AWS Lambda (Java)
 ---
 
 ![aws provider](https://img.shields.io/badge/provider-AWS-orange?logo=amazon-aws&color=ff9900) ![Build status](https://github.com/awslabs/aws-lambda-powertools-java/actions/workflows/build.yml/badge.svg) ![Maven Central](https://img.shields.io/maven-central/v/software.amazon.lambda/powertools-parent)
 
-Powertools is a suite of utilities for AWS Lambda Functions that makes tracing with AWS X-Ray, structured logging and creating custom metrics asynchronously easier.
+Powertools for AWS Lambda (Java) is a suite of utilities for AWS Lambda Functions that makes tracing with AWS X-Ray, structured logging and creating custom metrics asynchronously easier.
 
 ???+ tip
-    Powertools is also available for [Python](https://awslabs.github.io/aws-lambda-powertools-python/){target="_blank"}, [TypeScript](https://awslabs.github.io/aws-lambda-powertools-typescript/){target="_blank"}, and [.NET](https://awslabs.github.io/aws-lambda-powertools-dotnet/){target="_blank"}
+    Powertools for AWS Lambda  is also available for [Python](https://awslabs.github.io/aws-lambda-powertools-python/){target="_blank"}, [TypeScript](https://awslabs.github.io/aws-lambda-powertools-typescript/){target="_blank"}, and [.NET](https://awslabs.github.io/aws-lambda-powertools-dotnet/){target="_blank"}
 
 
 !!! tip "Looking for a quick run through of the core utilities?"
     Check out [this detailed blog post](https://aws.amazon.com/blogs/opensource/simplifying-serverless-best-practices-with-aws-lambda-powertools-java/) with a practical example. To dive deeper, 
-    the [AWS Lambda Powertools for Java workshop](https://catalog.us-east-1.prod.workshops.aws/workshops/a7011c82-e4af-4a52-80fa-fcd61f1dacd9/en-US/introduction) is a great next step.
+    the [Powertools for AWS Lambda (Java) workshop](https://catalog.us-east-1.prod.workshops.aws/workshops/a7011c82-e4af-4a52-80fa-fcd61f1dacd9/en-US/introduction) is a great next step.
 
 ## Tenets
 
@@ -28,14 +28,14 @@ This project separates core utilities that will be available in other runtimes v
 
 ## Install
 
-Powertools dependencies are available in Maven Central. You can use your favourite dependency management tool to install it
+Powertools for AWS Lambda (Java) dependencies are available in Maven Central. You can use your favourite dependency management tool to install it
 
 * [Maven](https://maven.apache.org/)
 * [Gradle](https://gradle.org)
 
 **Quick hello world examples using SAM CLI**
 
-You can use [SAM](https://aws.amazon.com/serverless/sam/) to quickly setup a serverless project including AWS Lambda Powertools for Java.
+You can use [SAM](https://aws.amazon.com/serverless/sam/) to quickly setup a serverless project including Powertools for AWS Lambda (Java).
 
 ```bash
   sam init --location gh:aws-samples/cookiecutter-aws-sam-powertools-java

--- a/docs/utilities/custom_resources.md
+++ b/docs/utilities/custom_resources.md
@@ -103,7 +103,7 @@ In both of the scenarios, powertools-java will return the `physicalResourceId` t
 
 #### Why do you need a physicalResourceId?
 
-It is recommended that you always explicitly provide a `physicalResourceId` in your response rather than letting powertools generate if for you because `physicalResourceId` has a crucial role in the lifecycle of a CloudFormation custom resource.
+It is recommended that you always explicitly provide a `physicalResourceId` in your response rather than letting Powertools for AWS Lambda (Java) generate if for you because `physicalResourceId` has a crucial role in the lifecycle of a CloudFormation custom resource.
 If the `physicalResourceId` changes between calls from Cloudformation, for instance in response to an `Update` event, Cloudformation [treats the resource update as a replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cfn-customresource.html).
 
 ### Customising a response

--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -390,7 +390,7 @@ The client was successful in receiving the result after the retry. Since the Lam
 
 This is automatically done when you annotate your Lambda handler with [@Idempotent annotation](#idempotent-annotation).
 
-To prevent against extended failed retries when a [Lambda function times out](https://aws.amazon.com/premiumsupport/knowledge-center/lambda-verify-invocation-timeouts/), Powertools calculates and includes the remaining invocation available time as part of the idempotency record.
+To prevent against extended failed retries when a [Lambda function times out](https://aws.amazon.com/premiumsupport/knowledge-center/lambda-verify-invocation-timeouts/), Powertools for AWS Lambda (Java) calculates and includes the remaining invocation available time as part of the idempotency record.
 
 !!! example
     If a second invocation happens **after** this timestamp, and the record is marked as `INPROGRESS`, we will execute the invocation again as if it was in the `EXPIRED` state.
@@ -846,8 +846,8 @@ public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent in
 }
 ```
 
-!!! tip "Tip: JMESPath Powertools functions are also available"
-    Built-in functions like `powertools_json`, `powertools_base64`, `powertools_base64_gzip` are also available to use in this utility. See [JMESPath Powertools functions](serialization.md)
+!!! tip "Tip: JMESPath Powertools for AWS Lambda (Java) functions are also available"
+    Built-in functions like `powertools_json`, `powertools_base64`, `powertools_base64_gzip` are also available to use in this utility. See [JMESPath Powertools for AWS Lambda (Java) functions](serialization.md)
 
 
 ## Testing your code

--- a/docs/utilities/serialization.md
+++ b/docs/utilities/serialization.md
@@ -250,7 +250,7 @@ It can also handle a collection of elements like the records of an SQS event:
 ## JMESPath functions
 
 !!! Tip
-    [JMESPath](https://jmespath.org/){target="_blank"} is a query language for JSON used by AWS CLI and AWS Lambda Powertools for Java to get a specific part of a json.
+    [JMESPath](https://jmespath.org/){target="_blank"} is a query language for JSON used by AWS CLI and Powertools for AWS Lambda (Java) to get a specific part of a json.
 
 ### Key features
 
@@ -261,11 +261,11 @@ It can also handle a collection of elements like the records of an SQS event:
 
 You might have events that contain encoded JSON payloads as string, base64, or even in compressed format. It is a common use case to decode and extract them partially or fully as part of your Lambda function invocation.
 
-You will generally use this in combination with other Lambda Powertools modules ([validation](validation.md) and [idempotency](idempotency.md)) where you might need to extract a portion of your data before using them.
+You will generally use this in combination with other Powertools for AWS Lambda (Java) modules ([validation](validation.md) and [idempotency](idempotency.md)) where you might need to extract a portion of your data before using them.
 
 ### Built-in functions
 
-Powertools provides the following JMESPath Functions to easily deserialize common encoded JSON payloads in Lambda functions:
+Powertools for AWS Lambda (Java) provides the following JMESPath Functions to easily deserialize common encoded JSON payloads in Lambda functions:
 
 #### powertools_json function
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,5 @@
 ## aws-lambda-powertools-examples
 
-This directory holds example projects demoing different components of the Lambda Powertools for Java.
+This directory holds example projects demoing different components of the Powertools for AWS Lambda (Java).
 
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -13,9 +13,9 @@
         <version>1.15.0</version>
     </parent>
 
-    <name>AWS Lambda Powertools for Java library Examples</name>
+    <name>Powertools for AWS Lambda (Java) library Examples</name>
     <description>
-        A suite of examples accompanying for AWS Lambda Powertools. 
+        A suite of examples accompanying for Powertools for AWS Lambda (Java).
     </description>
 
     <modules>

--- a/examples/powertools-examples-core/README.md
+++ b/examples/powertools-examples-core/README.md
@@ -1,6 +1,6 @@
 # CoreUtilities
 
-This project contains source code and supporting files for a serverless application that you can deploy with the SAM CLI. It includes [Lambda Powertools for operational best practices](https://github.com/awslabs/aws-lambda-powertools-java), and the following files and folders.
+This project contains source code and supporting files for a serverless application that you can deploy with the SAM CLI. It includes [Powertools for AWS Lambda (Java) for operational best practices](https://github.com/awslabs/aws-lambda-powertools-java), and the following files and folders.
 
 - HelloWorldFunction/src/main - Code for the application's Lambda function.
 - events - Invocation events that you can use to invoke the function.
@@ -133,6 +133,6 @@ aws cloudformation delete-stack --stack-name <Name-of-your-deployed-stack>
 
 See the [AWS SAM developer guide](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html) for an introduction to SAM specification, the SAM CLI, and serverless application concepts.
 
-Check the [AWS Lambda Powertools Java](https://awslabs.github.io/aws-lambda-powertools-java/) for more information on how to use and configure such tools
+Check the [Powertools for AWS Lambda (Java)](https://awslabs.github.io/aws-lambda-powertools-java/) for more information on how to use and configure such tools
 
 Next, you can use AWS Serverless Application Repository to deploy ready to use Apps that go beyond hello world samples and learn how authors developed their applications: [AWS Serverless Application Repository main page](https://aws.amazon.com/serverless/serverlessrepo/)

--- a/examples/powertools-examples-core/pom.xml
+++ b/examples/powertools-examples-core/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>powertools-examples-core</artifactId>
     <packaging>jar</packaging>
-    <name>AWS Lambda Powertools for Java library Examples - Core</name>
+    <name>Powertools for AWS Lambda (Java) library Examples - Core</name>
     
     <parent>
         <artifactId>powertools-examples</artifactId>

--- a/examples/powertools-examples-core/template.yaml
+++ b/examples/powertools-examples-core/template.yaml
@@ -12,7 +12,7 @@ Globals:
     Tracing: Active # https://docs.aws.amazon.com/lambda/latest/dg/lambda-x-ray.html
     Environment:
       Variables:
-        # Powertools env vars: https://awslabs.github.io/aws-lambda-powertools-python/#environment-variables
+        # Powertools for AWS Lambda (Java) env vars: https://awslabs.github.io/aws-lambda-powertools-python/#environment-variables
         POWERTOOLS_LOG_LEVEL: INFO
         POWERTOOLS_LOGGER_SAMPLE_RATE: 0.1
         POWERTOOLS_LOGGER_LOG_EVENT: true

--- a/examples/powertools-examples-idempotency/README.md
+++ b/examples/powertools-examples-idempotency/README.md
@@ -1,6 +1,6 @@
 # Idempotency
 
-This project contains an example of Lambda function using the idempotency module of Lambda Powertools for Java. For more information on this module, please refer to the [documentation](https://awslabs.github.io/aws-lambda-powertools-java/utilities/idempotency/).
+This project contains an example of Lambda function using the idempotency module of Powertools for AWS Lambda (Java). For more information on this module, please refer to the [documentation](https://awslabs.github.io/aws-lambda-powertools-java/utilities/idempotency/).
 
 ## Deploy the sample application
 

--- a/examples/powertools-examples-idempotency/pom.xml
+++ b/examples/powertools-examples-idempotency/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>powertools-examples-idempotency</artifactId>
     <packaging>jar</packaging>
-    <name>AWS Lambda Powertools for Java library Examples - Idempotency</name>
+    <name>Powertools for AWS Lambda (Java) library Examples - Idempotency</name>
 
     <parent>
         <artifactId>powertools-examples</artifactId>

--- a/examples/powertools-examples-parameters/README.md
+++ b/examples/powertools-examples-parameters/README.md
@@ -1,6 +1,6 @@
 # Parameters
 
-This project contains an example of Lambda function using the parameters module of Lambda Powertools for Java. For more information on this module, please refer to the [documentation](https://awslabs.github.io/aws-lambda-powertools-java/utilities/parameters/).
+This project contains an example of Lambda function using the parameters module of Powertools for AWS Lambda (Java). For more information on this module, please refer to the [documentation](https://awslabs.github.io/aws-lambda-powertools-java/utilities/parameters/).
 
 ## Deploy the sample application
 

--- a/examples/powertools-examples-parameters/pom.xml
+++ b/examples/powertools-examples-parameters/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>powertools-examples-parameters</artifactId>
     <packaging>jar</packaging>
-    <name>AWS Lambda Powertools for Java library Examples - Parameters</name>
+    <name>Powertools for AWS Lambda (Java) library Examples - Parameters</name>
 
     <parent>
         <artifactId>powertools-examples</artifactId>

--- a/examples/powertools-examples-serialization/README.md
+++ b/examples/powertools-examples-serialization/README.md
@@ -1,6 +1,6 @@
 # Deserialization
 
-This project contains an example of Lambda function using the serialization utilities module of Lambda Powertools for Java. For more information on this module, please refer to the [documentation](https://awslabs.github.io/aws-lambda-powertools-java/utilities/serialization/).
+This project contains an example of Lambda function using the serialization utilities module of Powertools for AWS Lambda (Java). For more information on this module, please refer to the [documentation](https://awslabs.github.io/aws-lambda-powertools-java/utilities/serialization/).
 
 ## Deploy the sample application
 

--- a/examples/powertools-examples-serialization/pom.xml
+++ b/examples/powertools-examples-serialization/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>powertools-examples-serialization</artifactId>
     <packaging>jar</packaging>
-    <name>AWS Lambda Powertools for Java library Examples - Serialization</name>
+    <name>Powertools for AWS Lambda (Java) library Examples - Serialization</name>
 
     <parent>
         <artifactId>powertools-examples</artifactId>

--- a/examples/powertools-examples-sqs/pom.xml
+++ b/examples/powertools-examples-sqs/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>powertools-examples-sqs</artifactId>
     <packaging>jar</packaging>
-    <name>AWS Lambda Powertools for Java library Examples - SQS</name>
+    <name>Powertools for AWS Lambda (Java) library Examples - SQS</name>
 
     <parent>
         <artifactId>powertools-examples</artifactId>

--- a/examples/powertools-examples-sqs/template.yaml
+++ b/examples/powertools-examples-sqs/template.yaml
@@ -11,7 +11,7 @@ Globals:
     Tracing: Active
     Environment:
       Variables:
-        # Powertools env vars: https://awslabs.github.io/aws-lambda-powertools-python/#environment-variables
+        # Powertools for AWS Lambda (Java) env vars: https://awslabs.github.io/aws-lambda-powertools-python/#environment-variables
         POWERTOOLS_LOG_LEVEL: INFO
         POWERTOOLS_LOGGER_SAMPLE_RATE: 0.1
         POWERTOOLS_LOGGER_LOG_EVENT: true

--- a/examples/powertools-examples-validation/README.md
+++ b/examples/powertools-examples-validation/README.md
@@ -1,6 +1,6 @@
 # Validation
 
-This project contains an example of Lambda function using the validation module of Lambda Powertools for Java. For more information on this module, please refer to the [documentation](https://awslabs.github.io/aws-lambda-powertools-java/utilities/validation/).
+This project contains an example of Lambda function using the validation module of Powertools for AWS Lambda (Java). For more information on this module, please refer to the [documentation](https://awslabs.github.io/aws-lambda-powertools-java/utilities/validation/).
 
 ## Deploy the sample application
 

--- a/examples/powertools-examples-validation/pom.xml
+++ b/examples/powertools-examples-validation/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>powertools-examples-validation</artifactId>
     <packaging>jar</packaging>
-    <name>AWS Lambda Powertools for Java library Examples - Validation</name>
+    <name>Powertools for AWS Lambda (Java) library Examples - Validation</name>
 
     <parent>
         <artifactId>powertools-examples</artifactId>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: AWS Lambda Powertools for Java
-site_description: AWS Lambda Powertools for Java
+site_name: Powertools for AWS Lambda (Java)
+site_description: Powertools for AWS Lambda (Java)
 site_author: Amazon Web Services
 nav:
   - Homepage: index.md

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>1.15.0</version>
     <packaging>pom</packaging>
 
-    <name>AWS Lambda Powertools for Java library Parent</name>
+    <name>Powertools for AWS Lambda (Java) library Parent</name>
     <description>
         A suite of utilities for AWS Lambda Functions that makes tracing with AWS X-Ray, structured logging and creating custom metrics asynchronously easier.
     </description>
@@ -48,7 +48,7 @@
 
     <developers>
         <developer>
-            <name>AWS Lambda Powertools team</name>
+            <name>Powertools for AWS Lambda (Java) team</name>
             <organization>Amazon Web Services</organization>
             <organizationUrl>https://aws.amazon.com/</organizationUrl>
         </developer>

--- a/powertools-cloudformation/src/main/java/software/amazon/lambda/powertools/cloudformation/AbstractCustomResourceHandler.java
+++ b/powertools-cloudformation/src/main/java/software/amazon/lambda/powertools/cloudformation/AbstractCustomResourceHandler.java
@@ -65,7 +65,7 @@ public abstract class AbstractCustomResourceHandler
         } catch (CustomResourceResponseException rse) {
             LOG.error("Unable to generate response. Sending empty failure to {}", responseUrl, rse);
             try {
-                // If the customers code throws an exception, Powertools should respond in a way that doesn't
+                // If the customers code throws an exception, Powertools for AWS Lambda (Java) should respond in a way that doesn't
                 // change the CloudFormation resources.
                 // In the case of a Update or Delete, a failure is sent with the existing PhysicalResourceId
                 // indicating no change.

--- a/powertools-cloudformation/src/main/java/software/amazon/lambda/powertools/cloudformation/Response.java
+++ b/powertools-cloudformation/src/main/java/software/amazon/lambda/powertools/cloudformation/Response.java
@@ -138,7 +138,7 @@ public class Response {
     }
 
     /**
-     * Creates a failed Response with no physicalResourceId set. Powertools will set the physicalResourceId to the
+     * Creates a failed Response with no physicalResourceId set. Powertools for AWS Lambda (Java) will set the physicalResourceId to the
      * Lambda LogStreamName
      *
      * The value returned for a PhysicalResourceId can change custom resource update operations. If the value returned
@@ -171,7 +171,7 @@ public class Response {
     }
 
     /**
-     * Creates a successful Response with no physicalResourceId set. Powertools will set the physicalResourceId to the
+     * Creates a successful Response with no physicalResourceId set. Powertools for AWS Lambda (Java) will set the physicalResourceId to the
      * Lambda LogStreamName
      *
      * The value returned for a PhysicalResourceId can change custom resource update operations. If the value returned

--- a/powertools-core/pom.xml
+++ b/powertools-core/pom.xml
@@ -13,7 +13,7 @@
         <version>1.15.0</version>
     </parent>
 
-    <name>AWS Lambda Powertools for Java library Core</name>
+    <name>Powertools for AWS Lambda (Java) library Core</name>
     <description>
         A suite of utilities for AWS Lambda Functions that makes tracing with AWS X-Ray, structured logging and creating custom metrics asynchronously easier.
     </description>
@@ -28,7 +28,7 @@
     </scm>
     <developers>
         <developer>
-            <name>AWS Lambda Powertools team</name>
+            <name>Powertools for AWS Lambda team</name>
             <organization>Amazon Web Services</organization>
             <organizationUrl>https://aws.amazon.com/</organizationUrl>
         </developer>

--- a/powertools-e2e-tests/README.md
+++ b/powertools-e2e-tests/README.md
@@ -1,5 +1,5 @@
 ## End-to-end tests
-This module is internal and meant to be used for end-to-end (E2E) testing of Lambda Powertools for Java. 
+This module is internal and meant to be used for end-to-end (E2E) testing of Powertools for AWS Lambda (Java). 
 
 __Prerequisites__: 
 - An AWS account is needed as well as a local environment able to reach this account 

--- a/powertools-e2e-tests/handlers/idempotency/pom.xml
+++ b/powertools-e2e-tests/handlers/idempotency/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>e2e-test-handler-idempotency</artifactId>
     <packaging>jar</packaging>
-    <name>A Lambda function using powertools idempotency</name>
+    <name>A Lambda function using Powertools for AWS Lambda (Java) idempotency</name>
 
     <dependencies>
         <dependency>

--- a/powertools-e2e-tests/handlers/logging/pom.xml
+++ b/powertools-e2e-tests/handlers/logging/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>e2e-test-handler-logging</artifactId>
     <packaging>jar</packaging>
-    <name>A Lambda function using powertools logging</name>
+    <name>A Lambda function using Powertools for AWS Lambda (Java) logging</name>
 
     <dependencies>
         <dependency>

--- a/powertools-e2e-tests/handlers/pom.xml
+++ b/powertools-e2e-tests/handlers/pom.xml
@@ -7,7 +7,7 @@
     <version>1.0.0</version>
     <packaging>pom</packaging>
     <name>Handlers for End-to-End tests</name>
-    <description>Fake handlers that use Lambda Powertools for Java.</description>
+    <description>Fake handlers that use Powertools for AWS Lambda (Java).</description>
 
     <properties>
         <lambda.powertools.version>1.14.0</lambda.powertools.version>

--- a/powertools-idempotency/pom.xml
+++ b/powertools-idempotency/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>powertools-idempotency</artifactId>
     <packaging>jar</packaging>
 
-    <name>AWS Lambda Powertools for Java library Idempotency</name>
+    <name>Powertools for AWS Lambda (Java) library Idempotency</name>
     <description>
 
     </description>
@@ -27,7 +27,7 @@
     </scm>
     <developers>
         <developer>
-            <name>AWS Lambda Powertools team</name>
+            <name>Powertools for AWS Lambda team</name>
             <organization>Amazon Web Services</organization>
             <organizationUrl>https://aws.amazon.com/</organizationUrl>
         </developer>

--- a/powertools-idempotency/src/main/java/software/amazon/lambda/powertools/idempotency/internal/IdempotencyHandler.java
+++ b/powertools-idempotency/src/main/java/software/amazon/lambda/powertools/idempotency/internal/IdempotencyHandler.java
@@ -88,7 +88,7 @@ public class IdempotencyHandler {
         } catch (IdempotencyKeyException ike) {
             throw ike;
         } catch (Exception e) {
-            throw new IdempotencyPersistenceLayerException("Failed to save in progress record to idempotency store. If you believe this is a powertools bug, please open an issue.", e);
+            throw new IdempotencyPersistenceLayerException("Failed to save in progress record to idempotency store. If you believe this is a Powertools for AWS Lambda (Java) bug, please open an issue.", e);
         }
         return getFunctionResponse();
     }
@@ -123,7 +123,7 @@ public class IdempotencyHandler {
         } catch (IdempotencyValidationException | IdempotencyKeyException vke) {
             throw vke;
         } catch (Exception e) {
-            throw new IdempotencyPersistenceLayerException("Failed to get record from idempotency store. If you believe this is a powertools bug, please open an issue.", e);
+            throw new IdempotencyPersistenceLayerException("Failed to get record from idempotency store. If you believe this is a Powertools for AWS Lambda (Java) bug, please open an issue.", e);
         }
     }
 
@@ -170,7 +170,7 @@ public class IdempotencyHandler {
             } catch (IdempotencyKeyException ke) {
                 throw ke;
             } catch (Exception e) {
-                throw new IdempotencyPersistenceLayerException("Failed to delete record from idempotency store. If you believe this is a powertools bug, please open an issue.", e);
+                throw new IdempotencyPersistenceLayerException("Failed to delete record from idempotency store. If you believe this is a Powertools for AWS Lambda (Java) bug, please open an issue.", e);
             }
             throw handlerException;
         }
@@ -178,7 +178,7 @@ public class IdempotencyHandler {
         try {
             persistenceStore.saveSuccess(data, response, Instant.now());
         } catch (Exception e) {
-            throw new IdempotencyPersistenceLayerException("Failed to update record state to success in idempotency store. If you believe this is a powertools bug, please open an issue.", e);
+            throw new IdempotencyPersistenceLayerException("Failed to update record state to success in idempotency store. If you believe this is a Powertools for AWS Lambda (Java) bug, please open an issue.", e);
         }
         return response;
     }

--- a/powertools-logging/pom.xml
+++ b/powertools-logging/pom.xml
@@ -13,7 +13,7 @@
         <version>1.15.0</version>
     </parent>
 
-    <name>AWS Lambda Powertools for Java library Logging</name>
+    <name>Powertools for AWS Lambda (Java) library Logging</name>
     <description>
         A suite of utilities for AWS Lambda Functions that makes tracing with AWS X-Ray, structured logging and creating custom metrics asynchronously easier.
     </description>
@@ -27,7 +27,7 @@
     </scm>
     <developers>
         <developer>
-            <name>AWS Lambda Powertools team</name>
+            <name>Powertools for AWS Lambda team</name>
             <organization>Amazon Web Services</organization>
             <organizationUrl>https://aws.amazon.com/</organizationUrl>
         </developer>

--- a/powertools-metrics/pom.xml
+++ b/powertools-metrics/pom.xml
@@ -13,7 +13,7 @@
         <version>1.15.0</version>
     </parent>
 
-    <name>AWS Lambda Powertools for Java library Metrics</name>
+    <name>Powertools for AWS Lambda (Java) library Metrics</name>
     <description>
         A suite of utilities for AWS Lambda Functions that make creating custom metrics via AWS Embedded Metric Format
         asynchronously easier.
@@ -28,7 +28,7 @@
     </scm>
     <developers>
         <developer>
-            <name>AWS Lambda Powertools team</name>
+            <name>Powertools for AWS Lambda team</name>
             <organization>Amazon Web Services</organization>
             <organizationUrl>https://aws.amazon.com/</organizationUrl>
         </developer>

--- a/powertools-parameters/pom.xml
+++ b/powertools-parameters/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>powertools-parameters</artifactId>
 
-    <name>AWS Lambda Powertools for Java library Parameters</name>
+    <name>Powertools for AWS Lambda (Java) library Parameters</name>
 
     <description>
         Set of utilities to retrieve parameters from Secrets Manager or SSM Parameter Store
@@ -27,7 +27,7 @@
     </scm>
     <developers>
         <developer>
-            <name>AWS Lambda Powertools team</name>
+            <name>Powertools for AWS Lambda team</name>
             <organization>Amazon Web Services</organization>
             <organizationUrl>https://aws.amazon.com/</organizationUrl>
         </developer>

--- a/powertools-parameters/src/main/java/software/amazon/lambda/powertools/parameters/DynamoDbProvider.java
+++ b/powertools-parameters/src/main/java/software/amazon/lambda/powertools/parameters/DynamoDbProvider.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 
 /**
  * Implements a {@link ParamProvider} on top of DynamoDB. The schema of the table
- * is described in the Powertools documentation.
+ * is described in the Powertools for AWS Lambda (Java) documentation.
  *
  * @see <a href="https://awslabs.github.io/aws-lambda-powertools-java/utilities/parameters">Parameters provider documentation</a>
  *

--- a/powertools-serialization/pom.xml
+++ b/powertools-serialization/pom.xml
@@ -13,7 +13,7 @@
     <artifactId>powertools-serialization</artifactId>
     <packaging>jar</packaging>
 
-    <name>AWS Lambda Powertools for Java library Serialization Utilities</name>
+    <name>Powertools for AWS Lambda (Java) library Serialization Utilities</name>
     <description>
 
     </description>
@@ -27,7 +27,7 @@
     </scm>
     <developers>
         <developer>
-            <name>AWS Lambda Powertools team</name>
+            <name>Powertools for AWS Lambda team</name>
             <organization>Amazon Web Services</organization>
             <organizationUrl>https://aws.amazon.com/</organizationUrl>
         </developer>

--- a/powertools-sqs/pom.xml
+++ b/powertools-sqs/pom.xml
@@ -13,7 +13,7 @@
         <version>1.15.0</version>
     </parent>
 
-    <name>AWS Lambda Powertools for Java library SQS</name>
+    <name>Powertools for AWS Lambda (Java) library SQS</name>
     <description>
         A suite of utilities for AWS Lambda Functions that makes tracing with AWS X-Ray, structured logging and creating custom metrics asynchronously easier.
     </description>
@@ -27,7 +27,7 @@
     </scm>
     <developers>
         <developer>
-            <name>AWS Lambda Powertools team</name>
+            <name>Powertools for AWS Lambda team</name>
             <organization>Amazon Web Services</organization>
             <organizationUrl>https://aws.amazon.com/</organizationUrl>
         </developer>

--- a/powertools-test-suite/pom.xml
+++ b/powertools-test-suite/pom.xml
@@ -13,9 +13,9 @@
         <version>1.15.0</version>
     </parent>
 
-    <name>AWS Lambda Powertools for Java library Test Suite</name>
+    <name>Powertools for AWS Lambda (Java) library Test Suite</name>
     <description>
-        A suite of tests for interactions between the various Powertools modules.
+        A suite of tests for interactions between the various Powertools for AWS Lambda (Java) modules.
     </description>
     <url>https://aws.amazon.com/lambda/</url>
     <issueManagement>
@@ -27,7 +27,7 @@
     </scm>
     <developers>
         <developer>
-            <name>AWS Lambda Powertools team</name>
+            <name>Powertools for AWS Lambda team</name>
             <organization>Amazon Web Services</organization>
             <organizationUrl>https://aws.amazon.com/</organizationUrl>
         </developer>

--- a/powertools-tracing/pom.xml
+++ b/powertools-tracing/pom.xml
@@ -13,7 +13,7 @@
         <version>1.15.0</version>
     </parent>
 
-    <name>AWS Lambda Powertools for Java library Tracing</name>
+    <name>Powertools for AWS Lambda (Java) library Tracing</name>
     <description>
         A suite of utilities for AWS Lambda Functions that makes tracing with AWS X-Ray, structured logging and creating custom metrics asynchronously easier.
     </description>
@@ -28,7 +28,7 @@
     </scm>
     <developers>
         <developer>
-            <name>AWS Lambda Powertools team</name>
+            <name>Powertools for AWS Lambda team</name>
             <organization>Amazon Web Services</organization>
             <organizationUrl>https://aws.amazon.com/</organizationUrl>
         </developer>

--- a/powertools-tracing/src/main/java/software/amazon/lambda/powertools/tracing/Tracing.java
+++ b/powertools-tracing/src/main/java/software/amazon/lambda/powertools/tracing/Tracing.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Target;
 
 /**
  * {@code Tracing} is used to signal that the annotated method should
- * be extended with the Powertools tracing functionality.
+ * be extended with the Powertools for AWS Lambda (Java) tracing functionality.
  *
  * <p>{@code Tracing} provides functionality to reduce the overhead
  * of performing common tracing tasks.</p>

--- a/powertools-validation/pom.xml
+++ b/powertools-validation/pom.xml
@@ -13,7 +13,7 @@
         <version>1.15.0</version>
     </parent>
 
-    <name>AWS Lambda Powertools for Java validation library</name>
+    <name>Powertools for AWS Lambda (Java) validation library</name>
     <description>
         Json schema validation for Lambda events and responses
     </description>
@@ -28,7 +28,7 @@
     </scm>
     <developers>
         <developer>
-            <name>AWS Lambda Powertools team</name>
+            <name>Powertools for AWS Lambda team</name>
             <organization>Amazon Web Services</organization>
             <organizationUrl>https://aws.amazon.com/</organizationUrl>
         </developer>


### PR DESCRIPTION
**Issue #, if available:** #1168 
## Description of changes:

<!--- One or two sentences as a summary of what's being changed -->

Located all references of Powertools/Lambda Powertools etc and updated to the new project name "Powertools for AWS Lambda" 

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [X] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [X] Update tests
* [X] Update docs
* [X] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
