### PR TITLE
chore: Swap implementation of `aspectj-maven-plugin` to support Java 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ And configure the aspectj-maven-plugin to compile-time weave (CTW) the aws-lambd
     <plugins>
         ...
         <plugin>
-             <groupId>org.codehaus.mojo</groupId>
+             <groupId>dev.aspectj</groupId>
              <artifactId>aspectj-maven-plugin</artifactId>
-             <version>1.14.0</version>
+             <version>1.13.1</version>
              <configuration>
                  <source>1.8</source>
                  <target>1.8</target>

--- a/docs/index.md
+++ b/docs/index.md
@@ -122,7 +122,8 @@ For more information about the project and available options refer to this [repo
         aspect 'software.amazon.lambda:powertools-logging:{{ powertools.version }}'
         aspect 'software.amazon.lambda:powertools-tracing:{{ powertools.version }}'
         aspect 'software.amazon.lambda:powertools-metrics:{{ powertools.version }}'
-        implementation 'org.aspectj:aspectjrt:1.9.19'
+//      This dependency is needed for Java17+, please uncomment it if you are using Java17+
+//      implementation 'org.aspectj:aspectjrt:1.9.19'
     }
 
     sourceCompatibility = 11

--- a/docs/index.md
+++ b/docs/index.md
@@ -122,6 +122,7 @@ For more information about the project and available options refer to this [repo
         aspect 'software.amazon.lambda:powertools-logging:{{ powertools.version }}'
         aspect 'software.amazon.lambda:powertools-tracing:{{ powertools.version }}'
         aspect 'software.amazon.lambda:powertools-metrics:{{ powertools.version }}'
+        implementation 'org.aspectj:aspectjrt:1.9.19'
     }
 
     sourceCompatibility = 11

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,9 +71,9 @@ For more information about the project and available options refer to this [repo
         <plugins>
             ...
             <plugin>
-                 <groupId>org.codehaus.mojo</groupId>
+                 <groupId>dev.aspectj</groupId>
                  <artifactId>aspectj-maven-plugin</artifactId>
-                 <version>1.14.0</version>
+                 <version>1.13.1</version>
                  <configuration>
                      <source>1.8</source>
                      <target>1.8</target>

--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -83,6 +83,7 @@ To install this utility, add the following dependency to your project.
     dependencies {
         ...
         aspect 'software.amazon.lambda:powertools-sqs:{{ powertools.version }}'
+        implementation 'org.aspectj:aspectjrt:1.9.19'
     }
     ```
 

--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -83,7 +83,8 @@ To install this utility, add the following dependency to your project.
     dependencies {
         ...
         aspect 'software.amazon.lambda:powertools-sqs:{{ powertools.version }}'
-        implementation 'org.aspectj:aspectjrt:1.9.19'
+//      This dependency is needed for Java17+, please uncomment it if you are using Java17+
+//      implementation 'org.aspectj:aspectjrt:1.9.19'
     }
     ```
 

--- a/docs/utilities/batch.md
+++ b/docs/utilities/batch.md
@@ -41,9 +41,9 @@ To install this utility, add the following dependency to your project.
         <plugins>
             ...
             <plugin>
-                 <groupId>org.codehaus.mojo</groupId>
+                 <groupId>dev.aspectj</groupId>
                  <artifactId>aspectj-maven-plugin</artifactId>
-                 <version>1.14.0</version>
+                 <version>1.13.1</version>
                  <configuration>
                      <source>1.8</source>
                      <target>1.8</target>

--- a/docs/utilities/idempotency.md
+++ b/docs/utilities/idempotency.md
@@ -43,9 +43,9 @@ times with the same parameters**. This makes idempotent operations safe to retry
         <plugins>
             ...
             <plugin>
-                 <groupId>org.codehaus.mojo</groupId>
+                 <groupId>dev.aspectj</groupId>
                  <artifactId>aspectj-maven-plugin</artifactId>
-                 <version>1.14.0</version>
+                 <version>1.13.1</version>
                  <configuration>
                      <source>1.8</source>
                      <target>1.8</target>

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -34,7 +34,8 @@ To install this utility, add the following dependency to your project.
      dependencies {
         ...
         aspect 'software.amazon.lambda:powertools-parameters:{{ powertools.version }}'
-        implementation 'org.aspectj:aspectjrt:1.9.19'
+//      This dependency is needed for Java17+, please uncomment it if you are using Java17+
+//      implementation 'org.aspectj:aspectjrt:1.9.19'
     }
     ```
 

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -441,9 +441,9 @@ If you want to use the ```@Param``` annotation in your project add configuration
         <plugins>
             ...
             <plugin>
-                 <groupId>org.codehaus.mojo</groupId>
+                 <groupId>dev.aspectj</groupId>
                  <artifactId>aspectj-maven-plugin</artifactId>
-                 <version>1.14.0</version>
+                 <version>1.13.1</version>
                  <configuration>
                      ...
                      <aspectLibraries>

--- a/docs/utilities/parameters.md
+++ b/docs/utilities/parameters.md
@@ -34,6 +34,7 @@ To install this utility, add the following dependency to your project.
      dependencies {
         ...
         aspect 'software.amazon.lambda:powertools-parameters:{{ powertools.version }}'
+        implementation 'org.aspectj:aspectjrt:1.9.19'
     }
     ```
 
@@ -482,5 +483,6 @@ If you want to use the ```@Param``` annotation in your project add configuration
     dependencies {
         ...
         aspect 'software.amazon.lambda:powertools-parameters:{{ powertools.version }}'
+        implementation 'org.aspectj:aspectjrt:1.9.19'
     }
     ```

--- a/docs/utilities/sqs_large_message_handling.md
+++ b/docs/utilities/sqs_large_message_handling.md
@@ -91,6 +91,7 @@ To install this utility, add the following dependency to your project.
     dependencies {
         ...
         aspect 'software.amazon.lambda:powertools-sqs:{{ powertools.version }}'
+        implementation 'org.aspectj:aspectjrt:1.9.19'
     }
     ```
 

--- a/docs/utilities/sqs_large_message_handling.md
+++ b/docs/utilities/sqs_large_message_handling.md
@@ -91,7 +91,8 @@ To install this utility, add the following dependency to your project.
     dependencies {
         ...
         aspect 'software.amazon.lambda:powertools-sqs:{{ powertools.version }}'
-        implementation 'org.aspectj:aspectjrt:1.9.19'
+//      This dependency is needed for Java17+, please uncomment it if you are using Java17+
+//      implementation 'org.aspectj:aspectjrt:1.9.19'
     }
     ```
 

--- a/docs/utilities/sqs_large_message_handling.md
+++ b/docs/utilities/sqs_large_message_handling.md
@@ -49,9 +49,9 @@ To install this utility, add the following dependency to your project.
         <plugins>
             ...
             <plugin>
-                 <groupId>org.codehaus.mojo</groupId>
+                 <groupId>dev.aspectj</groupId>
                  <artifactId>aspectj-maven-plugin</artifactId>
-                 <version>1.14.0</version>
+                 <version>1.13.1</version>
                  <configuration>
                      <source>1.8</source>
                      <target>1.8</target>

--- a/docs/utilities/validation.md
+++ b/docs/utilities/validation.md
@@ -72,6 +72,7 @@ To install this utility, add the following dependency to your project.
 
     dependencies {
         aspect 'software.amazon.lambda:powertools-validation:{{ powertools.version }}'
+        implementation 'org.aspectj:aspectjrt:1.9.19'
     }
     ```
 

--- a/docs/utilities/validation.md
+++ b/docs/utilities/validation.md
@@ -31,9 +31,9 @@ To install this utility, add the following dependency to your project.
         <plugins>
             ...
             <plugin>
-                 <groupId>org.codehaus.mojo</groupId>
+                 <groupId>dev.aspectj</groupId>
                  <artifactId>aspectj-maven-plugin</artifactId>
-                 <version>1.14.0</version>
+                 <version>1.13.1</version>
                  <configuration>
                      <source>1.8</source>
                      <target>1.8</target>

--- a/docs/utilities/validation.md
+++ b/docs/utilities/validation.md
@@ -72,7 +72,8 @@ To install this utility, add the following dependency to your project.
 
     dependencies {
         aspect 'software.amazon.lambda:powertools-validation:{{ powertools.version }}'
-        implementation 'org.aspectj:aspectjrt:1.9.19'
+//      This dependency is needed for Java17+, please uncomment it if you are using Java17+
+//      implementation 'org.aspectj:aspectjrt:1.9.19'
     }
     ```
 

--- a/examples/powertools-examples-core/pom.xml
+++ b/examples/powertools-examples-core/pom.xml
@@ -59,9 +59,9 @@
     <build>
       <plugins>
         <plugin>
-             <groupId>org.codehaus.mojo</groupId>
+             <groupId>dev.aspectj</groupId>
              <artifactId>aspectj-maven-plugin</artifactId>
-             <version>1.14.0</version>
+             <version>1.13.1</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>

--- a/examples/powertools-examples-idempotency/pom.xml
+++ b/examples/powertools-examples-idempotency/pom.xml
@@ -76,9 +76,9 @@
     <build>
       <plugins>
         <plugin>
-             <groupId>org.codehaus.mojo</groupId>
+             <groupId>dev.aspectj</groupId>
              <artifactId>aspectj-maven-plugin</artifactId>
-             <version>1.14.0</version>
+             <version>1.13.1</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>

--- a/examples/powertools-examples-parameters/pom.xml
+++ b/examples/powertools-examples-parameters/pom.xml
@@ -63,9 +63,9 @@
               <version>3.1.0</version>
           </plugin>
         <plugin>
-             <groupId>org.codehaus.mojo</groupId>
+             <groupId>dev.aspectj</groupId>
              <artifactId>aspectj-maven-plugin</artifactId>
-             <version>1.14.0</version>
+             <version>1.13.1</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>

--- a/examples/powertools-examples-sqs/pom.xml
+++ b/examples/powertools-examples-sqs/pom.xml
@@ -64,9 +64,9 @@
     <build>
       <plugins>
         <plugin>
-             <groupId>org.codehaus.mojo</groupId>
+             <groupId>dev.aspectj</groupId>
              <artifactId>aspectj-maven-plugin</artifactId>
-             <version>1.14.0</version>
+             <version>1.13.1</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>

--- a/examples/powertools-examples-validation/pom.xml
+++ b/examples/powertools-examples-validation/pom.xml
@@ -58,9 +58,9 @@
               <version>3.1.0</version>
           </plugin>
         <plugin>
-             <groupId>org.codehaus.mojo</groupId>
+             <groupId>dev.aspectj</groupId>
              <artifactId>aspectj-maven-plugin</artifactId>
-             <version>1.14.0</version>
+             <version>1.13.1</version>
              <configuration>
                  <source>${maven.compiler.source}</source>
                  <target>${maven.compiler.target}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <lambda.events.version>3.11.1</lambda.events.version>
         <lambda.serial.version>1.1.2</lambda.serial.version>
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-        <aspectj-maven-plugin.version>1.14.0</aspectj-maven-plugin.version>
+        <aspectj-maven-plugin.version>1.13.1</aspectj-maven-plugin.version>
         <maven-surefire-plugin.version>3.1.0</maven-surefire-plugin.version>
         <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
@@ -307,7 +307,7 @@
                     <version>${maven-compiler-plugin.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
+                    <groupId>dev.aspectj</groupId>
                     <artifactId>aspectj-maven-plugin</artifactId>
                     <version>${aspectj-maven-plugin.version}</version>
                 </plugin>
@@ -354,7 +354,7 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>dev.aspectj</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <version>${aspectj-maven-plugin.version}</version>
                 <configuration>

--- a/powertools-e2e-tests/handlers/idempotency/pom.xml
+++ b/powertools-e2e-tests/handlers/idempotency/pom.xml
@@ -27,7 +27,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>dev.aspectj</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <configuration>
                     <source>${maven.compiler.source}</source>

--- a/powertools-e2e-tests/handlers/logging/pom.xml
+++ b/powertools-e2e-tests/handlers/logging/pom.xml
@@ -27,7 +27,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>dev.aspectj</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <configuration>
                     <source>${maven.compiler.source}</source>

--- a/powertools-e2e-tests/handlers/metrics/pom.xml
+++ b/powertools-e2e-tests/handlers/metrics/pom.xml
@@ -27,7 +27,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>dev.aspectj</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <configuration>
                     <source>${maven.compiler.source}</source>

--- a/powertools-e2e-tests/handlers/pom.xml
+++ b/powertools-e2e-tests/handlers/pom.xml
@@ -18,7 +18,7 @@
         <lambda.java.core>1.2.2</lambda.java.core>
         <lambda.java.events>3.11.0</lambda.java.events>
         <maven.shade.version>3.2.4</maven.shade.version>
-        <aspectj.version>1.14.0</aspectj.version>
+        <aspectj.version>1.13.1</aspectj.version>
         <maven.compiler.version>3.10.1</maven.compiler.version>
     </properties>
 
@@ -99,7 +99,7 @@
                     </dependencies>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
+                    <groupId>dev.aspectj</groupId>
                     <artifactId>aspectj-maven-plugin</artifactId>
                     <version>${aspectj.version}</version>
                 </plugin>

--- a/powertools-e2e-tests/handlers/tracing/pom.xml
+++ b/powertools-e2e-tests/handlers/tracing/pom.xml
@@ -27,7 +27,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>dev.aspectj</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <configuration>
                     <source>${maven.compiler.source}</source>

--- a/powertools-serialization/pom.xml
+++ b/powertools-serialization/pom.xml
@@ -75,7 +75,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>dev.aspectj</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <version>${aspectj-maven-plugin.version}</version>
                 <configuration>

--- a/powertools-test-suite/pom.xml
+++ b/powertools-test-suite/pom.xml
@@ -115,9 +115,9 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>dev.aspectj</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
-                <version>1.14.0</version>
+                <version>1.13.1</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>


### PR DESCRIPTION
**Issue #:** https://github.com/awslabs/aws-lambda-powertools-java/issues/1156

## Description of changes:

According to https://github.com/mojohaus/aspectj-maven-plugin/issues/154 this plugin should be swapped with [dev-aspectj plugin](https://github.com/dev-aspectj/aspectj-maven-plugin), which works with Java 17 project.
This PR updates the repo, examples and docs to use the new plugin.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://awslabs.github.io/aws-lambda-powertools-java/#tenets)
* [ ] Update tests
* [x] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Breaking change checklist

<!--- Ignore if it's not a breaking change -->

**RFC issue #**:

* [ ] Migration process documented
* [ ] Implement warnings (if it can live side by side)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
