### PR TITLE
fix: Add maven central required information to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,19 @@
     <description>
         A suite of utilities for AWS Lambda Functions that makes tracing with AWS X-Ray, structured logging and creating custom metrics asynchronously easier.
     </description>
+    <scm>
+        <url>https://github.com/aws-powertools/powertools-lambda-java</url>
+        <connection>scm:git:git://github.com/aws-powertools/powertools-lambda-java.git</connection>
+        <developerConnection>scm:git:ssh://github.com:aws-powertools/powertools-lambda-java.git</developerConnection>
+    </scm>
+    <developers>
+        <developer>
+            <name>Powertools for AWS team</name>
+            <email>aws-powertools-maintainers@amazon.com</email>
+            <organization>Amazon Web Services Inc.</organization>
+            <organizationUrl>https://aws.amazon.com</organizationUrl>
+        </developer>
+    </developers>
     <url>https://aws.amazon.com/lambda/</url>
     <issueManagement>
         <system>GitHub Issues</system>

--- a/powertools-e2e-tests/pom.xml
+++ b/powertools-e2e-tests/pom.xml
@@ -180,7 +180,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>${maven.deploy.plugin.version}</version>
+                <version>3.1.2</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/powertools-parameters/powertools-parameters-tests/pom.xml
+++ b/powertools-parameters/powertools-parameters-tests/pom.xml
@@ -12,10 +12,6 @@
 
     <artifactId>powertools-parameters-tests</artifactId>
     <description>Powertools parameters tests that cut across all the parameters providers</description>
-    <properties>
-        <!-- Don't deploy the tests -->
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
 
     <dependencies>
         <dependency>
@@ -162,6 +158,14 @@
                                 <buildArg>-H:+UnlockExperimentalVMOptions</buildArg>
                                 <buildArg>-H:Log=registerResource:5</buildArg>
                             </buildArgs>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <version>3.1.2</version>
+                        <configuration>
+                            <skip>true</skip>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
**Issue #, if available:** https://github.com/aws-powertools/powertools-lambda-java/issues/1866

## Description of changes:
- Adds scm, developers to pom.xml in parent
- Skips deploying e2e tests and parameters tests

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply --> 

* [x] [Meet tenets criteria](https://docs.powertools.aws.dev/lambda-java/#tenets)
* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
