### PR TITLE
build(deps): Move wiremock to new version with patched CVEs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -374,9 +374,9 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>com.github.tomakehurst</groupId>
-                <artifactId>wiremock-jre8</artifactId>
-                <version>2.35.2</version>
+                <groupId>org.wiremock</groupId>
+                <artifactId>wiremock</artifactId>
+                <version>3.13.1</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/powertools-cloudformation/pom.xml
+++ b/powertools-cloudformation/pom.xml
@@ -14,8 +14,8 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>powertools-cloudformation</artifactId>
@@ -91,8 +91,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary

This addresses https://github.com/aws-powertools/powertools-lambda-java/security/dependabot/68.

Moved from legacy package to current version and namespace: https://mvnrepository.com/artifact/org.wiremock/wiremock/3.13.1

### Changes

I confirmed that this new includes the patched version of apache fileupload:

```sh
❯ mvn dependency:tree | grep fileupload
[INFO]    +- commons-fileupload:commons-fileupload:jar:1.6.0:test
```

Before it was 1.4.0 affected by the CVE reported in the dependabot alert.

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/1917

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.