### PR TITLE
docs(logger): fix logging environment variables names

### DIFF
--- a/docs/core/logging.md
+++ b/docs/core/logging.md
@@ -209,9 +209,9 @@ There are some other environment variables which can be set to modify Logging's 
 | Environment variable            | Type     | Description                                                                                                             |  
 |---------------------------------|----------|-------------------------------------------------------------------------------------------------------------------------|  
 | `POWERTOOLS_LOGGER_SAMPLE_RATE` | float    | Configure the sampling rate at which `DEBUG` logs should be included. See [sampling rate](#sampling-debug-logs)                  |  
-| `POWERTOOLS_LOG_EVENT`          | boolean  | Specify if the incoming Lambda event should be logged. See [Logging event](#logging-incoming-event)                     |  
-| `POWERTOOLS_LOG_RESPONSE`       | boolean  | Specify if the Lambda response should be logged. See [logging response](#logging-handler-response)                      |  
-| `POWERTOOLS_LOG_ERROR`          | boolean  | Specify if a Lambda uncaught exception should be logged. See [logging exception](#logging-handler-uncaught-exception  ) |  
+| `POWERTOOLS_LOGGER_LOG_EVENT`          | boolean  | Specify if the incoming Lambda event should be logged. See [Logging event](#logging-incoming-event)                     |  
+| `POWERTOOLS_LOGGER_LOG_RESPONSE`       | boolean  | Specify if the Lambda response should be logged. See [logging response](#logging-handler-response)                      |  
+| `POWERTOOLS_LOGGER_LOG_ERROR`          | boolean  | Specify if a Lambda uncaught exception should be logged. See [logging exception](#logging-handler-uncaught-exception  ) |  
 
 #### Logging configuration
 


### PR DESCRIPTION
## Summary

The table of environment variables had the wrong variable names, even though other references in the same file had the correct values

### Changes

Fixed the names of environment variables for logging

closes #2162 
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.