### PR TITLE
chore(ci): Fix sha256 formatting in git-chglog docker image reference

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,7 +243,7 @@ jobs:
         name: Create branch and update change log
         run: |
           git checkout -b ci-${{ github.run_id }}
-          docker run -v "${PWD}":/workdir quay.io/git-chglog/git-chglog:sha256:c791b1e8264387690cce4ce32e18b4f59ca3ffd8d55cb4093dc6de74529493f4 > CHANGELOG.md
+          docker run -v "${PWD}":/workdir quay.io/git-chglog/git-chglog@sha256:c791b1e8264387690cce4ce32e18b4f59ca3ffd8d55cb4093dc6de74529493f4 > CHANGELOG.md
           git commit -am "chore(ci): bump version to ${{ inputs.version }}"
           git push origin ci-${{ github.run_id }}
       - id: create_pr


### PR DESCRIPTION
## Summary

This PR fixes a small issue in how the sha256 reference was formatted in the `git-chglog` image reference within the release workflow.

### Changes

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/2077

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.