### PR TITLE
chore(ci): Move tag step before changelog generation.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,11 @@ jobs:
           git config user.email "151832416+aws-powertools-bot@users.noreply.github.com"
           git config pull.rebase true
           git config remote.origin.url >&-
+      - id: tag
+        name: Create tag
+        run: |
+          git tag -a v${{ inputs.version }} -m "Release v${{ inputs.version }}"
+          git push origin v${{ inputs.version }}
       - id: branch
         name: Create branch and update change log
         run: |
@@ -254,11 +259,6 @@ jobs:
             --body "This is an automated PR created from the following workflow: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - id: tag
-        name: Create tag
-        run: |
-          git tag -a v${{ inputs.version }} -m "Release v${{ inputs.version }}"
-          git push origin v${{ inputs.version }}
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The changelog workflow seems to need a git tag. Moving the step before the changelog generation.

### Changes

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/2077

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.