### PR TITLE
fix(serialization): Fix Joda time serialization for AWS events.

### DIFF
--- a/powertools-serialization/pom.xml
+++ b/powertools-serialization/pom.xml
@@ -47,6 +47,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-joda</artifactId>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/powertools-serialization/src/main/java/software/amazon/lambda/powertools/utilities/JsonConfig.java
+++ b/powertools-serialization/src/main/java/software/amazon/lambda/powertools/utilities/JsonConfig.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 
 import io.burt.jmespath.JmesPath;
 import io.burt.jmespath.RuntimeConfiguration;
@@ -41,11 +42,13 @@ public final class JsonConfig {
             // Don't throw an exception when json has extra fields you are not serializing on.
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
             // Ignore null values when writing json.
-            .serializationInclusion(JsonInclude.Include.NON_NULL)
+            .defaultPropertyInclusion(
+                    JsonInclude.Value.construct(JsonInclude.Include.NON_NULL, JsonInclude.Include.USE_DEFAULTS))
             // Write times as a String instead of a Long so its human-readable.
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
             // Sort fields in alphabetical order
             .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+            .addModule(new JodaModule())
             .build();
 
     private static final ThreadLocal<ObjectMapper> om = ThreadLocal.withInitial(objectMapperSupplier);

--- a/powertools-serialization/src/test/java/software/amazon/lambda/powertools/utilities/EventDeserializerTest.java
+++ b/powertools-serialization/src/test/java/software/amazon/lambda/powertools/utilities/EventDeserializerTest.java
@@ -18,6 +18,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static software.amazon.lambda.powertools.utilities.EventDeserializer.extractDataFrom;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
 import com.amazonaws.services.lambda.runtime.events.ActiveMQEvent;
@@ -34,41 +41,37 @@ import com.amazonaws.services.lambda.runtime.events.SNSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
 import com.amazonaws.services.lambda.runtime.tests.annotations.Event;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
+import com.fasterxml.jackson.databind.JsonNode;
+
 import software.amazon.lambda.powertools.utilities.model.Order;
 import software.amazon.lambda.powertools.utilities.model.Product;
 
-public class EventDeserializerTest {
+class EventDeserializerTest {
 
     @Test
-    public void testDeserializeStringAsString_shouldReturnString() {
+    void testDeserializeStringAsString_shouldReturnString() {
         String stringEvent = "Hello World";
         String result = extractDataFrom(stringEvent).as(String.class);
         assertThat(result).isEqualTo(stringEvent);
     }
 
     @Test
-    public void testDeserializeStringAsObject_shouldReturnObject() {
+    void testDeserializeStringAsObject_shouldReturnObject() {
         String productStr = "{\"id\":1234, \"name\":\"product\", \"price\":42}";
         Product product = extractDataFrom(productStr).as(Product.class);
         assertProduct(product);
     }
 
     @Test
-    public void testDeserializeStringArrayAsList_shouldReturnList() {
-        String productStr =
-                "[{\"id\":1234, \"name\":\"product\", \"price\":42}, {\"id\":2345, \"name\":\"product2\", \"price\":43}]";
+    void testDeserializeStringArrayAsList_shouldReturnList() {
+        String productStr = "[{\"id\":1234, \"name\":\"product\", \"price\":42}, {\"id\":2345, \"name\":\"product2\", \"price\":43}]";
         List<Product> products = extractDataFrom(productStr).asListOf(Product.class);
         assertThat(products).hasSize(2);
         assertProduct(products.get(0));
     }
 
     @Test
-    public void testDeserializeStringAsList_shouldThrowException() {
+    void testDeserializeStringAsList_shouldThrowException() {
         String productStr = "{\"id\":1234, \"name\":\"product\", \"price\":42}";
         assertThatThrownBy(() -> extractDataFrom(productStr).asListOf(Product.class))
                 .isInstanceOf(EventDeserializationException.class)
@@ -76,7 +79,7 @@ public class EventDeserializerTest {
     }
 
     @Test
-    public void testDeserializeMapAsObject_shouldReturnObject() {
+    void testDeserializeMapAsObject_shouldReturnObject() {
         Map<String, Object> map = new HashMap<>();
         map.put("id", 1234);
         map.put("name", "product");
@@ -87,21 +90,21 @@ public class EventDeserializerTest {
 
     @ParameterizedTest
     @Event(value = "apigw_event.json", type = APIGatewayProxyRequestEvent.class)
-    public void testDeserializeAPIGWEventBodyAsObject_shouldReturnObject(APIGatewayProxyRequestEvent event) {
+    void testDeserializeAPIGWEventBodyAsObject_shouldReturnObject(APIGatewayProxyRequestEvent event) {
         Product product = extractDataFrom(event).as(Product.class);
         assertProduct(product);
     }
 
     @ParameterizedTest
     @Event(value = "sns_event.json", type = SNSEvent.class)
-    public void testDeserializeSNSEventMessageAsObject_shouldReturnObject(SNSEvent event) {
+    void testDeserializeSNSEventMessageAsObject_shouldReturnObject(SNSEvent event) {
         Product product = extractDataFrom(event).as(Product.class);
         assertProduct(product);
     }
 
     @ParameterizedTest
     @Event(value = "sqs_event.json", type = SQSEvent.class)
-    public void testDeserializeSQSEventMessageAsList_shouldReturnList(SQSEvent event) {
+    void testDeserializeSQSEventMessageAsList_shouldReturnList(SQSEvent event) {
         List<Product> products = extractDataFrom(event).asListOf(Product.class);
         assertThat(products).hasSize(2);
         assertProduct(products.get(0));
@@ -109,7 +112,7 @@ public class EventDeserializerTest {
 
     @ParameterizedTest
     @Event(value = "kinesis_event.json", type = KinesisEvent.class)
-    public void testDeserializeKinesisEventMessageAsList_shouldReturnList(KinesisEvent event) {
+    void testDeserializeKinesisEventMessageAsList_shouldReturnList(KinesisEvent event) {
         List<Product> products = extractDataFrom(event).asListOf(Product.class);
         assertThat(products).hasSize(2);
         assertProduct(products.get(0));
@@ -117,7 +120,7 @@ public class EventDeserializerTest {
 
     @ParameterizedTest
     @Event(value = "kafka_event.json", type = KafkaEvent.class)
-    public void testDeserializeKafkaEventMessageAsList_shouldReturnList(KafkaEvent event) {
+    void testDeserializeKafkaEventMessageAsList_shouldReturnList(KafkaEvent event) {
         List<Product> products = extractDataFrom(event).asListOf(Product.class);
         assertThat(products).hasSize(2);
         assertProduct(products.get(0));
@@ -125,7 +128,7 @@ public class EventDeserializerTest {
 
     @ParameterizedTest
     @Event(value = "sqs_event.json", type = SQSEvent.class)
-    public void testDeserializeSQSEventMessageAsObject_shouldThrowException(SQSEvent event) {
+    void testDeserializeSQSEventMessageAsObject_shouldThrowException(SQSEvent event) {
         assertThatThrownBy(() -> extractDataFrom(event).as(Product.class))
                 .isInstanceOf(EventDeserializationException.class)
                 .hasMessageContaining("consider using 'asListOf' instead");
@@ -133,7 +136,7 @@ public class EventDeserializerTest {
 
     @ParameterizedTest
     @Event(value = "apigw_event.json", type = APIGatewayProxyRequestEvent.class)
-    public void testDeserializeAPIGatewayEventAsList_shouldThrowException(APIGatewayProxyRequestEvent event) {
+    void testDeserializeAPIGatewayEventAsList_shouldThrowException(APIGatewayProxyRequestEvent event) {
         assertThatThrownBy(() -> extractDataFrom(event).asListOf(Product.class))
                 .isInstanceOf(EventDeserializationException.class)
                 .hasMessageContaining("consider using 'as' instead")
@@ -142,14 +145,14 @@ public class EventDeserializerTest {
 
     @ParameterizedTest
     @Event(value = "custom_event_map.json", type = HashMap.class)
-    public void testDeserializeAPIGatewayMapEventAsList_shouldThrowException(Map<String, Order> event) {
+    void testDeserializeAPIGatewayMapEventAsList_shouldThrowException(Map<String, Order> event) {
         assertThatThrownBy(() -> extractDataFrom(event).asListOf(Order.class))
                 .isInstanceOf(EventDeserializationException.class)
                 .hasMessage("The content of this event is not a list, consider using 'as' instead");
     }
 
     @Test
-    public void testDeserializeEmptyEventAsList_shouldThrowException() {
+    void testDeserializeEmptyEventAsList_shouldThrowException() {
         assertThatThrownBy(() -> extractDataFrom(null).asListOf(Product.class))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("Event content is null: the event may be malformed (missing fields)");
@@ -157,14 +160,14 @@ public class EventDeserializerTest {
 
     @ParameterizedTest
     @Event(value = "apigw_event_no_body.json", type = APIGatewayProxyRequestEvent.class)
-    public void testDeserializeAPIGatewayNoBody_shouldThrowException(APIGatewayProxyRequestEvent event) {
+    void testDeserializeAPIGatewayNoBody_shouldThrowException(APIGatewayProxyRequestEvent event) {
         assertThatThrownBy(() -> extractDataFrom(event).as(Product.class))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("Event content is null: the event may be malformed (missing fields)");
     }
 
     @Test
-    public void testDeserializeAPIGatewayNoBodyAsList_shouldThrowException() {
+    void testDeserializeAPIGatewayNoBodyAsList_shouldThrowException() {
         assertThatThrownBy(() -> extractDataFrom(new Object()).asListOf(Product.class))
                 .isInstanceOf(EventDeserializationException.class)
                 .hasMessage("The content of this event is not a list, consider using 'as' instead");
@@ -172,18 +175,17 @@ public class EventDeserializerTest {
 
     @ParameterizedTest
     @Event(value = "sqs_event_no_body.json", type = SQSEvent.class)
-    public void testDeserializeSQSEventNoBody_shouldThrowException(SQSEvent event) {
+    void testDeserializeSQSEventNoBody_shouldThrowException(SQSEvent event) {
         List<Product> products = extractDataFrom(event).asListOf(Product.class);
         assertThat(products.get(0)).isNull();
     }
 
     @Test
-    public void testDeserializeProductAsProduct_shouldReturnProduct() {
+    void testDeserializeProductAsProduct_shouldReturnProduct() {
         Product myProduct = new Product(1234, "product", 42);
         Product product = extractDataFrom(myProduct).as(Product.class);
         assertProduct(product);
     }
-
 
     private void assertProduct(Product product) {
         assertThat(product)
@@ -193,28 +195,28 @@ public class EventDeserializerTest {
 
     @ParameterizedTest
     @Event(value = "scheduled_event.json", type = ScheduledEvent.class)
-    public void testDeserializeScheduledEventMessageAsObject_shouldReturnObject(ScheduledEvent event) {
+    void testDeserializeScheduledEventMessageAsObject_shouldReturnObject(ScheduledEvent event) {
         Product product = extractDataFrom(event).as(Product.class);
         assertProduct(product);
     }
 
     @ParameterizedTest
     @Event(value = "alb_event.json", type = ApplicationLoadBalancerRequestEvent.class)
-    public void testDeserializeALBEventMessageAsObjectShouldReturnObject(ApplicationLoadBalancerRequestEvent event) {
+    void testDeserializeALBEventMessageAsObjectShouldReturnObject(ApplicationLoadBalancerRequestEvent event) {
         Product product = extractDataFrom(event).as(Product.class);
         assertProduct(product);
     }
 
     @ParameterizedTest
     @Event(value = "cwl_event.json", type = CloudWatchLogsEvent.class)
-    public void testDeserializeCWLEventMessageAsObjectShouldReturnObject(CloudWatchLogsEvent event) {
+    void testDeserializeCWLEventMessageAsObjectShouldReturnObject(CloudWatchLogsEvent event) {
         Product product = extractDataFrom(event).as(Product.class);
         assertProduct(product);
     }
 
     @ParameterizedTest
     @Event(value = "kf_event.json", type = KinesisFirehoseEvent.class)
-    public void testDeserializeKFEventMessageAsListShouldReturnList(KinesisFirehoseEvent event) {
+    void testDeserializeKFEventMessageAsListShouldReturnList(KinesisFirehoseEvent event) {
         List<Product> products = extractDataFrom(event).asListOf(Product.class);
         assertThat(products).hasSize(1);
         assertProduct(products.get(0));
@@ -222,7 +224,7 @@ public class EventDeserializerTest {
 
     @ParameterizedTest
     @Event(value = "amq_event.json", type = ActiveMQEvent.class)
-    public void testDeserializeAMQEventMessageAsListShouldReturnList(ActiveMQEvent event) {
+    void testDeserializeAMQEventMessageAsListShouldReturnList(ActiveMQEvent event) {
         List<Product> products = extractDataFrom(event).asListOf(Product.class);
         assertThat(products).hasSize(1);
         assertProduct(products.get(0));
@@ -230,7 +232,7 @@ public class EventDeserializerTest {
 
     @ParameterizedTest
     @Event(value = "rabbitmq_event.json", type = RabbitMQEvent.class)
-    public void testDeserializeRabbitMQEventMessageAsListShouldReturnList(RabbitMQEvent event) {
+    void testDeserializeRabbitMQEventMessageAsListShouldReturnList(RabbitMQEvent event) {
         List<Product> products = extractDataFrom(event).asListOf(Product.class);
         assertThat(products).hasSize(1);
         assertProduct(products.get(0));
@@ -238,7 +240,7 @@ public class EventDeserializerTest {
 
     @ParameterizedTest
     @Event(value = "kasip_event.json", type = KinesisAnalyticsStreamsInputPreprocessingEvent.class)
-    public void testDeserializeKasipEventMessageAsListShouldReturnList(
+    void testDeserializeKasipEventMessageAsListShouldReturnList(
             KinesisAnalyticsStreamsInputPreprocessingEvent event) {
         List<Product> products = extractDataFrom(event).asListOf(Product.class);
         assertThat(products).hasSize(1);
@@ -247,7 +249,7 @@ public class EventDeserializerTest {
 
     @ParameterizedTest
     @Event(value = "kafip_event.json", type = KinesisAnalyticsFirehoseInputPreprocessingEvent.class)
-    public void testDeserializeKafipEventMessageAsListShouldReturnList(
+    void testDeserializeKafipEventMessageAsListShouldReturnList(
             KinesisAnalyticsFirehoseInputPreprocessingEvent event) {
         List<Product> products = extractDataFrom(event).asListOf(Product.class);
         assertThat(products).hasSize(1);
@@ -256,16 +258,138 @@ public class EventDeserializerTest {
 
     @ParameterizedTest
     @Event(value = "apigwv2_event.json", type = APIGatewayV2HTTPEvent.class)
-    public void testDeserializeApiGWV2EventMessageAsObjectShouldReturnObject(APIGatewayV2HTTPEvent event) {
+    void testDeserializeApiGWV2EventMessageAsObjectShouldReturnObject(APIGatewayV2HTTPEvent event) {
         Product product = extractDataFrom(event).as(Product.class);
         assertProduct(product);
     }
 
     @ParameterizedTest
     @Event(value = "cfcr_event.json", type = CloudFormationCustomResourceEvent.class)
-    public void testDeserializeCfcrEventMessageAsObjectShouldReturnObject(CloudFormationCustomResourceEvent event) {
+    void testDeserializeCfcrEventMessageAsObjectShouldReturnObject(CloudFormationCustomResourceEvent event) {
         Product product = extractDataFrom(event).as(Product.class);
         assertProduct(product);
+    }
+
+    @ParameterizedTest
+    @Event(value = "scheduled_event.json", type = ScheduledEvent.class)
+    void testSerializeScheduledEvent_shouldReturnValidJson(ScheduledEvent event) throws Exception {
+        String json = JsonConfig.get().getObjectMapper().valueToTree(event).toString();
+        JsonNode parsed = JsonConfig.get().getObjectMapper().readTree(json);
+        assertThat(parsed.has("detail")).isTrue();
+    }
+
+    @ParameterizedTest
+    @Event(value = "apigw_event.json", type = APIGatewayProxyRequestEvent.class)
+    void testSerializeAPIGatewayEvent_shouldReturnValidJson(APIGatewayProxyRequestEvent event) throws Exception {
+        String json = JsonConfig.get().getObjectMapper().valueToTree(event).toString();
+        JsonNode parsed = JsonConfig.get().getObjectMapper().readTree(json);
+        assertThat(parsed.has("body")).isTrue();
+    }
+
+    @ParameterizedTest
+    @Event(value = "sqs_event.json", type = SQSEvent.class)
+    void testSerializeSQSEvent_shouldReturnValidJson(SQSEvent event) throws Exception {
+        String json = JsonConfig.get().getObjectMapper().valueToTree(event).toString();
+        JsonNode parsed = JsonConfig.get().getObjectMapper().readTree(json);
+        assertThat(parsed.has("records")).isTrue();
+    }
+
+    @ParameterizedTest
+    @Event(value = "sns_event.json", type = SNSEvent.class)
+    void testSerializeSNSEvent_shouldReturnValidJson(SNSEvent event) throws Exception {
+        String json = JsonConfig.get().getObjectMapper().valueToTree(event).toString();
+        JsonNode parsed = JsonConfig.get().getObjectMapper().readTree(json);
+        assertThat(parsed.has("records")).isTrue();
+    }
+
+    @ParameterizedTest
+    @Event(value = "kinesis_event.json", type = KinesisEvent.class)
+    void testSerializeKinesisEvent_shouldReturnValidJson(KinesisEvent event) throws Exception {
+        String json = JsonConfig.get().getObjectMapper().valueToTree(event).toString();
+        JsonNode parsed = JsonConfig.get().getObjectMapper().readTree(json);
+        assertThat(parsed.has("records")).isTrue();
+    }
+
+    @ParameterizedTest
+    @Event(value = "kafka_event.json", type = KafkaEvent.class)
+    void testSerializeKafkaEvent_shouldReturnValidJson(KafkaEvent event) throws Exception {
+        String json = JsonConfig.get().getObjectMapper().valueToTree(event).toString();
+        JsonNode parsed = JsonConfig.get().getObjectMapper().readTree(json);
+        assertThat(parsed.has("records")).isTrue();
+    }
+
+    @ParameterizedTest
+    @Event(value = "alb_event.json", type = ApplicationLoadBalancerRequestEvent.class)
+    void testSerializeALBEvent_shouldReturnValidJson(ApplicationLoadBalancerRequestEvent event) throws Exception {
+        String json = JsonConfig.get().getObjectMapper().valueToTree(event).toString();
+        JsonNode parsed = JsonConfig.get().getObjectMapper().readTree(json);
+        assertThat(parsed.has("body")).isTrue();
+    }
+
+    @ParameterizedTest
+    @Event(value = "cwl_event.json", type = CloudWatchLogsEvent.class)
+    void testSerializeCWLEvent_shouldReturnValidJson(CloudWatchLogsEvent event) throws Exception {
+        String json = JsonConfig.get().getObjectMapper().valueToTree(event).toString();
+        JsonNode parsed = JsonConfig.get().getObjectMapper().readTree(json);
+        assertThat(parsed.has("awsLogs")).isTrue();
+    }
+
+    @ParameterizedTest
+    @Event(value = "kf_event.json", type = KinesisFirehoseEvent.class)
+    void testSerializeKFEvent_shouldReturnValidJson(KinesisFirehoseEvent event) throws Exception {
+        String json = JsonConfig.get().getObjectMapper().valueToTree(event).toString();
+        JsonNode parsed = JsonConfig.get().getObjectMapper().readTree(json);
+        assertThat(parsed.has("records")).isTrue();
+    }
+
+    @ParameterizedTest
+    @Event(value = "amq_event.json", type = ActiveMQEvent.class)
+    void testSerializeAMQEvent_shouldReturnValidJson(ActiveMQEvent event) throws Exception {
+        String json = JsonConfig.get().getObjectMapper().valueToTree(event).toString();
+        JsonNode parsed = JsonConfig.get().getObjectMapper().readTree(json);
+        assertThat(parsed.has("messages")).isTrue();
+    }
+
+    @ParameterizedTest
+    @Event(value = "rabbitmq_event.json", type = RabbitMQEvent.class)
+    void testSerializeRabbitMQEvent_shouldReturnValidJson(RabbitMQEvent event) throws Exception {
+        String json = JsonConfig.get().getObjectMapper().valueToTree(event).toString();
+        JsonNode parsed = JsonConfig.get().getObjectMapper().readTree(json);
+        assertThat(parsed.has("rmqMessagesByQueue")).isTrue();
+    }
+
+    @ParameterizedTest
+    @Event(value = "kasip_event.json", type = KinesisAnalyticsStreamsInputPreprocessingEvent.class)
+    void testSerializeKasipEvent_shouldReturnValidJson(KinesisAnalyticsStreamsInputPreprocessingEvent event)
+            throws Exception {
+        String json = JsonConfig.get().getObjectMapper().valueToTree(event).toString();
+        JsonNode parsed = JsonConfig.get().getObjectMapper().readTree(json);
+        assertThat(parsed.has("records")).isTrue();
+    }
+
+    @ParameterizedTest
+    @Event(value = "kafip_event.json", type = KinesisAnalyticsFirehoseInputPreprocessingEvent.class)
+    void testSerializeKafipEvent_shouldReturnValidJson(KinesisAnalyticsFirehoseInputPreprocessingEvent event)
+            throws Exception {
+        String json = JsonConfig.get().getObjectMapper().valueToTree(event).toString();
+        JsonNode parsed = JsonConfig.get().getObjectMapper().readTree(json);
+        assertThat(parsed.has("records")).isTrue();
+    }
+
+    @ParameterizedTest
+    @Event(value = "apigwv2_event.json", type = APIGatewayV2HTTPEvent.class)
+    void testSerializeApiGWV2Event_shouldReturnValidJson(APIGatewayV2HTTPEvent event) throws Exception {
+        String json = JsonConfig.get().getObjectMapper().valueToTree(event).toString();
+        JsonNode parsed = JsonConfig.get().getObjectMapper().readTree(json);
+        assertThat(parsed.has("body")).isTrue();
+    }
+
+    @ParameterizedTest
+    @Event(value = "cfcr_event.json", type = CloudFormationCustomResourceEvent.class)
+    void testSerializeCfcrEvent_shouldReturnValidJson(CloudFormationCustomResourceEvent event) throws Exception {
+        String json = JsonConfig.get().getObjectMapper().valueToTree(event).toString();
+        JsonNode parsed = JsonConfig.get().getObjectMapper().readTree(json);
+        assertThat(parsed.has("resourceProperties")).isTrue();
     }
 
 }

--- a/powertools-serialization/src/test/java/software/amazon/lambda/powertools/utilities/jmespath/Base64FunctionTest.java
+++ b/powertools-serialization/src/test/java/software/amazon/lambda/powertools/utilities/jmespath/Base64FunctionTest.java
@@ -16,21 +16,24 @@ package software.amazon.lambda.powertools.utilities.jmespath;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
+
 import io.burt.jmespath.Expression;
-import java.io.IOException;
-import org.junit.jupiter.api.Test;
 import software.amazon.lambda.powertools.utilities.JsonConfig;
 
-public class Base64FunctionTest {
+class Base64FunctionTest {
 
     @Test
-    public void testPowertoolsBase64() throws IOException {
-        JsonNode event =
-                JsonConfig.get().getObjectMapper().readTree(this.getClass().getResourceAsStream("/custom_event.json"));
-        Expression<JsonNode> expression =
-                JsonConfig.get().getJmesPath().compile("basket.powertools_base64(hiddenProduct)");
+    void testPowertoolsBase64() throws IOException {
+        JsonNode event = JsonConfig.get().getObjectMapper()
+                .readTree(this.getClass().getResourceAsStream("/custom_event.json"));
+        Expression<JsonNode> expression = JsonConfig.get().getJmesPath()
+                .compile("basket.powertools_base64(hiddenProduct)");
         JsonNode result = expression.search(event);
         assertThat(result.getNodeType()).isEqualTo(JsonNodeType.STRING);
         assertThat(result.asText()).isEqualTo("{\n" +

--- a/powertools-serialization/src/test/java/software/amazon/lambda/powertools/utilities/jmespath/Base64GZipFunctionTest.java
+++ b/powertools-serialization/src/test/java/software/amazon/lambda/powertools/utilities/jmespath/Base64GZipFunctionTest.java
@@ -16,18 +16,21 @@ package software.amazon.lambda.powertools.utilities.jmespath;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
+
 import io.burt.jmespath.Expression;
 import io.burt.jmespath.JmesPathType;
-import java.io.IOException;
-import org.junit.jupiter.api.Test;
 import software.amazon.lambda.powertools.utilities.JsonConfig;
 
-public class Base64GZipFunctionTest {
+class Base64GZipFunctionTest {
 
     @Test
-    public void testConstructor() {
+    void testConstructor() {
         Base64GZipFunction base64GZipFunction = new Base64GZipFunction();
         assertThat(base64GZipFunction.name()).isEqualTo("powertools_base64_gzip");
         assertThat(base64GZipFunction.argumentConstraints().expectedType().toLowerCase()).isEqualTo(
@@ -38,18 +41,18 @@ public class Base64GZipFunctionTest {
     }
 
     @Test
-    public void testPowertoolsGzip() throws IOException {
+    void testPowertoolsGzip() throws IOException {
         JsonNode event = JsonConfig.get().getObjectMapper()
                 .readTree(this.getClass().getResourceAsStream("/custom_event_gzip.json"));
-        Expression<JsonNode> expression =
-                JsonConfig.get().getJmesPath().compile("basket.powertools_base64_gzip(hiddenProduct)");
+        Expression<JsonNode> expression = JsonConfig.get().getJmesPath()
+                .compile("basket.powertools_base64_gzip(hiddenProduct)");
         JsonNode result = expression.search(event);
         assertThat(result.getNodeType()).isEqualTo(JsonNodeType.STRING);
         assertThat(result.asText()).isEqualTo("{  \"id\": 43242,  \"name\": \"FooBar XY\",  \"price\": 258}");
     }
 
     @Test
-    public void testPowertoolsGzipEmptyJsonAttribute() throws IOException {
+    void testPowertoolsGzipEmptyJsonAttribute() throws IOException {
         JsonNode event = JsonConfig.get().getObjectMapper()
                 .readTree(this.getClass().getResourceAsStream("/custom_event_gzip.json"));
         Expression<JsonNode> expression = JsonConfig.get().getJmesPath().compile("basket.powertools_base64_gzip('')");
@@ -58,7 +61,7 @@ public class Base64GZipFunctionTest {
     }
 
     @Test
-    public void testPowertoolsGzipWrongArgumentType() throws IOException {
+    void testPowertoolsGzipWrongArgumentType() throws IOException {
         JsonNode event = JsonConfig.get().getObjectMapper()
                 .readTree(this.getClass().getResourceAsStream("/custom_event_gzip.json"));
         Expression<JsonNode> expression = JsonConfig.get().getJmesPath().compile("basket.powertools_base64_gzip(null)");
@@ -68,21 +71,20 @@ public class Base64GZipFunctionTest {
     }
 
     @Test
-    public void testBase64GzipDecompressNull() {
+    void testBase64GzipDecompressNull() {
         String result = Base64GZipFunction.decompress(null);
         assertThat(result).isNull();
     }
 
     @Test
-    public void testPowertoolsGzipNotCompressedJsonAttribute() throws IOException {
+    void testPowertoolsGzipNotCompressedJsonAttribute() throws IOException {
         JsonNode event = JsonConfig.get().getObjectMapper()
                 .readTree(this.getClass().getResourceAsStream("/custom_event_gzip.json"));
-        Expression<JsonNode> expression =
-                JsonConfig.get().getJmesPath().compile("basket.powertools_base64_gzip(encodedString)");
+        Expression<JsonNode> expression = JsonConfig.get().getJmesPath()
+                .compile("basket.powertools_base64_gzip(encodedString)");
         JsonNode result = expression.search(event);
         assertThat(result.getNodeType()).isEqualTo(JsonNodeType.STRING);
         assertThat(result.asText()).isEqualTo("test");
     }
-
 
 }

--- a/powertools-serialization/src/test/java/software/amazon/lambda/powertools/utilities/jmespath/JsonFunctionTest.java
+++ b/powertools-serialization/src/test/java/software/amazon/lambda/powertools/utilities/jmespath/JsonFunctionTest.java
@@ -16,17 +16,20 @@ package software.amazon.lambda.powertools.utilities.jmespath;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
+
 import io.burt.jmespath.Expression;
-import java.io.IOException;
-import org.junit.jupiter.api.Test;
 import software.amazon.lambda.powertools.utilities.JsonConfig;
 
-public class JsonFunctionTest {
+class JsonFunctionTest {
 
     @Test
-    public void testJsonFunction() throws IOException {
+    void testJsonFunction() throws IOException {
         JsonNode event = JsonConfig.get().getObjectMapper()
                 .readTree(this.getClass().getResourceAsStream("/custom_event_json.json"));
         Expression<JsonNode> expression = JsonConfig.get().getJmesPath().compile("powertools_json(body)");
@@ -38,7 +41,7 @@ public class JsonFunctionTest {
     }
 
     @Test
-    public void testJsonFunctionChild() throws IOException {
+    void testJsonFunctionChild() throws IOException {
         JsonNode event = JsonConfig.get().getObjectMapper()
                 .readTree(this.getClass().getResourceAsStream("/custom_event_json.json"));
         Expression<JsonNode> expression = JsonConfig.get().getJmesPath().compile("powertools_json(body).list[0].item");


### PR DESCRIPTION
## Summary

Some AWS Events still use Joda time. We need to add the Joda time Jackson module to be able to serialize them as valid json during `@Logging(logEvent = true)`. Additionally, it is needed to be able to extract correlation IDs from these events.

This PR adds the Joda time module to `powertools-serialization` which is used across the library (e.g. in Logging) for all serialization purposes.

### Changes

**Issue number:** #2251 

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.