### PR TITLE
chore(ci): Enable Java 25 builds.

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -47,6 +47,7 @@ on:
       - 'powertools-large-messages/**'
       - 'powertools-logging/**'
       - 'powertools-metrics/**'
+      - 'powertools-kafka/**'
       - 'powertools-parameters/**'
       - 'powertools-serialization/**'
       - 'powertools-sqs/**'
@@ -72,6 +73,7 @@ jobs:
           - 11
           - 17
           - 21
+          - 25
     steps:
       - id: checkout
         name: Checkout repository


### PR DESCRIPTION
## Summary

Enabling Java 25 builds in GH actions.

### Changes

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/2263

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.