### PR TITLE
improv(batch): Propagate trace entity to worker threads during parallel processing.

### DIFF
--- a/powertools-batch/src/main/java/software/amazon/lambda/powertools/batch/handler/KinesisStreamsBatchMessageHandler.java
+++ b/powertools-batch/src/main/java/software/amazon/lambda/powertools/batch/handler/KinesisStreamsBatchMessageHandler.java
@@ -14,22 +14,25 @@
 
 package software.amazon.lambda.powertools.batch.handler;
 
-
-import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
-import com.amazonaws.services.lambda.runtime.events.StreamsEventResponse;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.KinesisEvent;
+import com.amazonaws.services.lambda.runtime.events.StreamsEventResponse;
+
 import software.amazon.lambda.powertools.batch.internal.MultiThreadMDC;
+import software.amazon.lambda.powertools.batch.internal.XRayTraceEntityPropagator;
 import software.amazon.lambda.powertools.utilities.EventDeserializer;
 
 /**
@@ -49,10 +52,10 @@ public class KinesisStreamsBatchMessageHandler<M> implements BatchMessageHandler
     private final BiConsumer<KinesisEvent.KinesisEventRecord, Throwable> failureHandler;
 
     public KinesisStreamsBatchMessageHandler(BiConsumer<KinesisEvent.KinesisEventRecord, Context> rawMessageHandler,
-                                             BiConsumer<M, Context> messageHandler,
-                                             Class<M> messageClass,
-                                             Consumer<KinesisEvent.KinesisEventRecord> successHandler,
-                                             BiConsumer<KinesisEvent.KinesisEventRecord, Throwable> failureHandler) {
+            BiConsumer<M, Context> messageHandler,
+            Class<M> messageClass,
+            Consumer<KinesisEvent.KinesisEventRecord> successHandler,
+            BiConsumer<KinesisEvent.KinesisEventRecord, Throwable> failureHandler) {
 
         this.rawMessageHandler = rawMessageHandler;
         this.messageHandler = messageHandler;
@@ -76,14 +79,23 @@ public class KinesisStreamsBatchMessageHandler<M> implements BatchMessageHandler
     @Override
     public StreamsEventResponse processBatchInParallel(KinesisEvent event, Context context) {
         MultiThreadMDC multiThreadMDC = new MultiThreadMDC();
+        Object capturedSubsegment = XRayTraceEntityPropagator.captureTraceEntity();
 
         List<StreamsEventResponse.BatchItemFailure> batchItemFailures = event.getRecords()
                 .parallelStream() // Parallel processing
                 .map(eventRecord -> {
-                    multiThreadMDC.copyMDCToThread(Thread.currentThread().getName());
-                    Optional<StreamsEventResponse.BatchItemFailure> failureOpt = processBatchItem(eventRecord, context);
-                    multiThreadMDC.removeThread(Thread.currentThread().getName());
-                    return failureOpt;
+                    AtomicReference<Optional<StreamsEventResponse.BatchItemFailure>> result = new AtomicReference<>();
+
+                    XRayTraceEntityPropagator.runWithEntity(capturedSubsegment, () -> {
+                        multiThreadMDC.copyMDCToThread(Thread.currentThread().getName());
+                        try {
+                            result.set(processBatchItem(eventRecord, context));
+                        } finally {
+                            multiThreadMDC.removeThread(Thread.currentThread().getName());
+                        }
+                    });
+
+                    return result.get();
                 })
                 .filter(Optional::isPresent)
                 .map(Optional::get)
@@ -95,21 +107,29 @@ public class KinesisStreamsBatchMessageHandler<M> implements BatchMessageHandler
     @Override
     public StreamsEventResponse processBatchInParallel(KinesisEvent event, Context context, Executor executor) {
         MultiThreadMDC multiThreadMDC = new MultiThreadMDC();
+        Object capturedSubsegment = XRayTraceEntityPropagator.captureTraceEntity();
 
         List<StreamsEventResponse.BatchItemFailure> batchItemFailures = new ArrayList<>();
         List<CompletableFuture<Void>> futures = event.getRecords().stream()
                 .map(eventRecord -> CompletableFuture.runAsync(() -> {
-                    multiThreadMDC.copyMDCToThread(Thread.currentThread().getName());
-                    Optional<StreamsEventResponse.BatchItemFailure> failureOpt = processBatchItem(eventRecord, context);
-                    failureOpt.ifPresent(batchItemFailures::add);
-                    multiThreadMDC.removeThread(Thread.currentThread().getName());
+                    XRayTraceEntityPropagator.runWithEntity(capturedSubsegment, () -> {
+                        multiThreadMDC.copyMDCToThread(Thread.currentThread().getName());
+                        try {
+                            Optional<StreamsEventResponse.BatchItemFailure> failureOpt = processBatchItem(eventRecord,
+                                    context);
+                            failureOpt.ifPresent(batchItemFailures::add);
+                        } finally {
+                            multiThreadMDC.removeThread(Thread.currentThread().getName());
+                        }
+                    });
                 }, executor))
                 .collect(Collectors.toList());
         futures.forEach(CompletableFuture::join);
         return StreamsEventResponse.builder().withBatchItemFailures(batchItemFailures).build();
     }
 
-    private Optional<StreamsEventResponse.BatchItemFailure> processBatchItem(KinesisEvent.KinesisEventRecord eventRecord, Context context) {
+    private Optional<StreamsEventResponse.BatchItemFailure> processBatchItem(
+            KinesisEvent.KinesisEventRecord eventRecord, Context context) {
         try {
             LOGGER.debug("Processing item {}", eventRecord.getEventID());
 
@@ -141,8 +161,8 @@ public class KinesisStreamsBatchMessageHandler<M> implements BatchMessageHandler
                 }
             }
 
-            return Optional.of(StreamsEventResponse.BatchItemFailure.builder().withItemIdentifier(eventRecord.getKinesis().getSequenceNumber()).build());
+            return Optional.of(StreamsEventResponse.BatchItemFailure.builder()
+                    .withItemIdentifier(eventRecord.getKinesis().getSequenceNumber()).build());
         }
     }
 }
-

--- a/powertools-batch/src/main/java/software/amazon/lambda/powertools/batch/internal/XRayTraceEntityPropagator.java
+++ b/powertools-batch/src/main/java/software/amazon/lambda/powertools/batch/internal/XRayTraceEntityPropagator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates.
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package software.amazon.lambda.powertools.batch.internal;
+
+import java.lang.reflect.Method;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class to propagate X-Ray trace entity context to worker threads using reflection.
+ * Reflection is used to avoid taking a dependency on X-RAY SDK.
+ */
+public final class XRayTraceEntityPropagator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(XRayTraceEntityPropagator.class);
+    private static final boolean XRAY_AVAILABLE;
+    private static final Method GET_TRACE_ENTITY_METHOD;
+
+    // We do the more "expensive" Class.forName in this static block to detect exactly once at import time if X-RAY
+    // is available or not. Subsequent <method>.invoke() are very fast on modern JDKs.
+    static {
+        Method method = null;
+        boolean available = false;
+
+        try {
+            Class<?> awsXRayClass = Class.forName("com.amazonaws.xray.AWSXRay");
+            method = awsXRayClass.getMethod("getTraceEntity");
+            available = true;
+            LOGGER.debug("X-Ray SDK detected. Trace context will be propagated to worker threads.");
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            LOGGER.debug("X-Ray SDK not detected. Trace context propagation disabled");
+        }
+
+        GET_TRACE_ENTITY_METHOD = method;
+        XRAY_AVAILABLE = available;
+    }
+
+    private XRayTraceEntityPropagator() {
+        // Utility class
+    }
+
+    public static Object captureTraceEntity() {
+        if (!XRAY_AVAILABLE) {
+            return null;
+        }
+
+        try {
+            return GET_TRACE_ENTITY_METHOD.invoke(null);
+        } catch (Exception e) {
+            // We don't want to break batch processing if this fails.
+            LOGGER.warn("Failed to capture trace entity.", e);
+            return null;
+        }
+    }
+
+    // See https://docs.aws.amazon.com/xray/latest/devguide/scorekeep-workerthreads.html
+    public static void runWithEntity(Object traceEntity, Runnable runnable) {
+        if (!XRAY_AVAILABLE || traceEntity == null) {
+            runnable.run();
+            return;
+        }
+
+        try {
+            traceEntity.getClass().getMethod("run", Runnable.class).invoke(traceEntity, runnable);
+        } catch (Exception e) {
+            // We don't want to break batch processing if this fails.
+            LOGGER.warn("Failed to run with trace entity, falling back to direct execution.", e);
+            runnable.run();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes an issue when using `@Tracing` together with parallel batch processing.

**Before**

When using parallel batch processing (without passing a custom `Executor`) we use a `parallelStream()` under the hood. A `parallelStream()` uses the common fork-join pool plus the main thread for processing. What happened was that some of sub-segments were not correctly attached to the parent `## handleRequest` sub-segment. The reason is that X-RAY SDK maintains thread local trace entity instances. Hence, only the sub-sgements from the main thread and not those of the fork-join pool threads were correctly attached to the parent segment leading to a tracing output like this:

<img width="810" height="417" alt="Screenshot 2025-11-18 at 15 12 28" src="https://github.com/user-attachments/assets/2df500e0-c544-4975-8990-2825d7cddfc4" />

**After**

This PR introduces propagation of the main thread's trace entity to the worker threads of the parallel batch processing worker threads. This fixes the issue such that all sub-segments are correctly attached to their parent segments. See screenshot after:

<img width="844" height="730" alt="image (8)" src="https://github.com/user-attachments/assets/a33f310a-db90-456f-855f-55d398e327dd" />

### Changes

Added `XRayTraceEntityPropagator` as a reflection wrapper around the X-RAY SDK methods needed for trace propagation following documentation at https://docs.aws.amazon.com/xray/latest/devguide/scorekeep-workerthreads.html. 

The reason why we use reflection is because we should not take a dependency on the X-RAY SDK in the batch module. When X-RAY is not available, this will lead to a no-op.

We also update the documentation with better guidance on when to choose which concurrency model.

Note for reviewers: Created separate issue for addressing code duplication: https://github.com/aws-powertools/powertools-lambda-java/issues/2302. 

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/1671

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.