### PR TITLE
fix(metrics): Clear custom dimensions when flushing.

### DIFF
--- a/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/internal/EmfMetricsLogger.java
+++ b/powertools-metrics/src/main/java/software/amazon/lambda/powertools/metrics/internal/EmfMetricsLogger.java
@@ -164,6 +164,27 @@ public class EmfMetricsLogger implements Metrics {
             }
         } else {
             emfLogger.flush();
+
+            // Clear custom dimensions after flush while preserving default dimensions
+            clearCustomDimensions();
+        }
+    }
+
+    private void clearCustomDimensions() {
+        // Reset all dimensions in the EMF logger
+        emfLogger.resetDimensions(false);
+
+        // Re-apply default dimensions if they exist
+        if (!defaultDimensions.isEmpty()) {
+            DimensionSet emfDimensionSet = new DimensionSet();
+            defaultDimensions.forEach((key, value) -> {
+                try {
+                    emfDimensionSet.addDimension(key, value);
+                } catch (Exception e) {
+                    // Ignore dimension errors
+                }
+            });
+            emfLogger.setDimensions(emfDimensionSet);
         }
     }
 
@@ -198,7 +219,8 @@ public class EmfMetricsLogger implements Metrics {
             metrics.setNamespace(this.namespace);
         }
         if (!defaultDimensions.isEmpty()) {
-            metrics.setDefaultDimensions(software.amazon.lambda.powertools.metrics.model.DimensionSet.of(defaultDimensions));
+            metrics.setDefaultDimensions(
+                    software.amazon.lambda.powertools.metrics.model.DimensionSet.of(defaultDimensions));
         }
         properties.forEach(metrics::addMetadata);
 


### PR DESCRIPTION
## Summary

This PR clears custom dimensions when `.flush()` is called on the metrics instance. Note: This does not affect calls to `.flushMetrics()` since they create a temporary second metrics instance that supports flushing on its own with its own dimension set (copy). 

This was the default behavior in v1 of Powertools Java but is also the same behavior in the other runtimes such as TypeScript (see [comment](https://github.com/aws-powertools/powertools-lambda-java/issues/2327#issuecomment-3636551148)).

On flush, we clear:
- Custom dimensions and preserve default dimensions
- Metadata (also consistent with TS runtime)

### Changes

**Issue number:** https://github.com/aws-powertools/powertools-lambda-java/issues/2327

<!-------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/aws-powertools/powertools-lambda-java/blob/main/CONTRIBUTING.md#sending-a-pull-request
- Check that there isn't already a PR that addresses the same issue. If you find a duplicate, please leave a comment under the existing PR so we can discuss how to move forward
- Check that the change meets the project's tenets https://docs.powertools.aws.dev/lambda/java/latest/#tenets
- Add a PR title that follows the conventional commit semantics - https://www.conventionalcommits.org/en/v1.0.0/
- If relevant, add tests that prove that the change is effective and works
- Whenever relevant, make sure to comment functions/methods/types and make appropriate changes to the documentation
------->

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.